### PR TITLE
Add administrative wands

### DIFF
--- a/src/main/java/com/almuradev/almura/Almura.java
+++ b/src/main/java/com/almuradev/almura/Almura.java
@@ -6,6 +6,7 @@
 package com.almuradev.almura;
 
 import com.almuradev.almura.client.ClientProxy;
+import com.almuradev.almura.pack.Pack;
 import com.almuradev.almura.server.ServerProxy;
 import cpw.mods.fml.common.Mod;
 import cpw.mods.fml.common.Mod.EventHandler;
@@ -20,6 +21,7 @@ import org.apache.logging.log4j.Logger;
 @Mod(modid = Almura.MOD_ID)
 public class Almura {
 
+    public static final Pack INTERNAL_PACK = new Pack("internal");
     public static final String MOD_ID = "almura";
     public static final Logger LOGGER = LogManager.getLogger(Almura.MOD_ID);
     public static final SimpleNetworkWrapper NETWORK_FORGE = new SimpleNetworkWrapper("AM|FOR");

--- a/src/main/java/com/almuradev/almura/CommonProxy.java
+++ b/src/main/java/com/almuradev/almura/CommonProxy.java
@@ -5,6 +5,8 @@
  */
 package com.almuradev.almura;
 
+import com.almuradev.almura.items.Items;
+import com.almuradev.almura.items.wands.FireballWand;
 import com.almuradev.almura.lang.LanguageRegistry;
 import com.almuradev.almura.lang.Languages;
 import com.almuradev.almura.pack.INodeContainer;
@@ -75,6 +77,7 @@ public class CommonProxy {
         FMLCommonHandler.instance().bus().register(this);
         MinecraftForge.EVENT_BUS.register(this);
         Tabs.fakeStaticLoad();
+        Items.fakeStaticLoad();
 
         Pack.loadAllContent();
     }

--- a/src/main/java/com/almuradev/almura/client/gui/AlmuraGui.java
+++ b/src/main/java/com/almuradev/almura/client/gui/AlmuraGui.java
@@ -12,7 +12,9 @@ import net.malisis.core.client.gui.GuiTexture;
 import net.malisis.core.client.gui.MalisisGui;
 import net.malisis.core.client.gui.component.UIComponent;
 import net.malisis.core.client.gui.icon.GuiIcon;
+import net.minecraft.client.Minecraft;
 import net.minecraft.util.ResourceLocation;
+import org.lwjgl.input.Keyboard;
 
 import java.awt.*;
 import java.io.IOException;
@@ -39,6 +41,7 @@ public abstract class AlmuraGui extends MalisisGui {
     public AlmuraGui(AlmuraGui parent) {
         renderer.setDefaultTexture(TEXTURE_DEFAULT);
         this.parent = Optional.fromNullable(parent);
+        mc = Minecraft.getMinecraft();
     }
 
     /**
@@ -56,14 +59,23 @@ public abstract class AlmuraGui extends MalisisGui {
     protected abstract void setup();
 
     /**
-     * Displays the parent screen
+     * Closes the current screen and displays the parent screen
      */
-    protected void displayParent() {
-        if (parent.isPresent()) {
-            mc.displayGuiScreen(parent.get());
-        } else {
-            mc.displayGuiScreen(null);
+    @Override
+    public void close() {
+        Keyboard.enableRepeatEvents(false);
+        if (mc.thePlayer != null) {
+            mc.thePlayer.closeScreen();
         }
+        mc.displayGuiScreen(parent.isPresent() ? parent.get() : null);
+        mc.setIngameFocus();
+    }
+
+    protected int getPaddedX(UIComponent component, int padding) {
+        if (component == null) {
+            return 0;
+        }
+        return component.getX() + component.getWidth() + padding;
     }
 
     protected int getPaddedY(UIComponent component, int padding) {

--- a/src/main/java/com/almuradev/almura/client/gui/guide/InfoguideGui.java
+++ b/src/main/java/com/almuradev/almura/client/gui/guide/InfoguideGui.java
@@ -149,7 +149,7 @@ public class InfoguideGui extends AlmuraGui {
                 mc.displayGuiScreen(new GuiModList(this));
                 break;
             case "button.close":
-                displayParent();
+                close();
                 break;
         }
     }

--- a/src/main/java/com/almuradev/almura/client/gui/ingame/IngameBlockInformation.java
+++ b/src/main/java/com/almuradev/almura/client/gui/ingame/IngameBlockInformation.java
@@ -1,0 +1,126 @@
+/**
+ * This file is part of Almura, All Rights Reserved.
+ *
+ * Copyright (c) 2014 AlmuraDev <http://github.com/AlmuraDev/>
+ */
+package com.almuradev.almura.client.gui.ingame;
+
+import com.almuradev.almura.client.ChatColor;
+import com.almuradev.almura.client.gui.AlmuraGui;
+import com.google.common.eventbus.Subscribe;
+import net.malisis.core.client.gui.Anchor;
+import net.malisis.core.client.gui.component.container.UIBackgroundContainer;
+import net.malisis.core.client.gui.component.control.UIMoveHandle;
+import net.malisis.core.client.gui.component.decoration.UIImage;
+import net.malisis.core.client.gui.component.decoration.UILabel;
+import net.malisis.core.client.gui.component.interaction.UIButton;
+import net.minecraft.block.Block;
+import net.minecraft.item.ItemStack;
+
+import java.text.DecimalFormat;
+
+public class IngameBlockInformation extends AlmuraGui {
+
+    private final Block block;
+    private final ItemStack stack;
+    private final int metadata;
+    private final float hardness;
+
+    /**
+     * Creates an gui with a parent screen and calls {@link AlmuraGui#setup}, if the parent is null then no background will be added
+
+     * @param parent the {@link AlmuraGui} that we came from
+     */
+    public IngameBlockInformation(AlmuraGui parent, Block block, ItemStack stack, int metadata, float hardness) {
+        super(parent);
+        this.block = block;
+        this.stack = stack;
+        this.metadata = metadata;
+        this.hardness = hardness;
+        setup();
+    }
+
+    @Override
+    protected void setup() {
+        final UIBackgroundContainer window = new UIBackgroundContainer(this, 175, 150);
+        window.setAnchor(Anchor.CENTER | Anchor.MIDDLE);
+        window.setColor(Integer.MIN_VALUE);
+        window.setBackgroundAlpha(125);
+
+        final int padding = 5;
+        final DecimalFormat decimal = new DecimalFormat("#.##");
+
+        final UIImage blockImage = new UIImage(this, stack);
+        if (stack.getItem() == null) {
+            blockImage.setIcon(block.getIcon(0, 0));
+        }
+        blockImage.setPosition(padding, padding, Anchor.LEFT | Anchor.TOP);
+
+        final String localized = stack.getItem() == null ? block.getLocalizedName() : stack.getDisplayName();
+        final UILabel localizedNameLabel = new UILabel(this, ChatColor.WHITE + getFormattedString(localized, 22, "..."));
+        localizedNameLabel.setPosition(getPaddedX(blockImage, padding), padding + 3, Anchor.LEFT | Anchor.TOP);
+
+        final UILabel unlocalizedNameLabel = new UILabel(this, ChatColor.GRAY + getFormattedString(block.getUnlocalizedName(), 60, "..."));
+        unlocalizedNameLabel.setPosition(getPaddedX(blockImage, padding), getPaddedY(localizedNameLabel, 0), Anchor.LEFT | Anchor.TOP);
+        unlocalizedNameLabel.setFontScale(0.5f);
+
+        final UILabel soundLabel = new UILabel(this, ChatColor.GRAY + "Step sound: " + block.stepSound.soundName);
+        soundLabel.setPosition(padding, getPaddedY(unlocalizedNameLabel, padding), Anchor.LEFT | Anchor.TOP);
+
+        final UILabel metadataLabel = new UILabel(this, ChatColor.GRAY + "Metadata: " + metadata);
+        metadataLabel.setPosition(padding, getPaddedY(soundLabel, padding), Anchor.LEFT | Anchor.TOP);
+
+        final UILabel lightOpacityLabel = new UILabel(this, ChatColor.GRAY + "Light opacity: " + block.getLightOpacity());
+        lightOpacityLabel.setPosition(padding, getPaddedY(metadataLabel, padding), Anchor.LEFT | Anchor.TOP);
+
+        final UILabel lightValueLabel = new UILabel(this, ChatColor.GRAY + "Light value: " + block.getLightValue());
+        lightValueLabel.setPosition(padding, getPaddedY(lightOpacityLabel, padding), Anchor.LEFT | Anchor.TOP);
+
+        final UILabel hardnessLabel = new UILabel(this, ChatColor.GRAY + "Hardness: " + decimal.format(hardness));
+        hardnessLabel.setPosition(padding, getPaddedY(lightValueLabel, padding), Anchor.LEFT | Anchor.TOP);
+
+        final UILabel
+                blockBoundsLabel =
+                new UILabel(this, ChatColor.GRAY + String
+                        .format("Block bounds: %1$sx%2$sx%3$s", decimal.format(block.getBlockBoundsMaxX()),
+                                decimal.format(block.getBlockBoundsMaxY()), decimal.format(block.getBlockBoundsMaxZ())));
+        blockBoundsLabel.setPosition(padding, getPaddedY(hardnessLabel, padding), Anchor.LEFT | Anchor.TOP);
+
+        final String harvestTool = block.getHarvestTool(metadata);
+        if (harvestTool != null && !harvestTool.isEmpty()) {
+            final UILabel harvestToolLabel = new UILabel(this, ChatColor.GRAY + "Harvest tool: " + harvestTool);
+            harvestToolLabel.setPosition(padding, getPaddedY(blockBoundsLabel, padding), Anchor.LEFT | Anchor.TOP);
+            window.add(harvestToolLabel);
+        }
+
+        final UIButton closeButton = new UIButton(this, "Close");
+        closeButton.setSize(50, 14);
+        closeButton.setPosition(-padding, -padding, Anchor.RIGHT | Anchor.BOTTOM);
+        closeButton.setName("button.close");
+        closeButton.register(this);
+
+        window.add(blockImage, localizedNameLabel, unlocalizedNameLabel, soundLabel, metadataLabel, lightOpacityLabel, lightValueLabel, hardnessLabel,
+                   blockBoundsLabel, closeButton);
+
+        new UIMoveHandle(this, window);
+
+        addToScreen(window);
+    }
+
+    @Subscribe
+    public void onButtonClick(UIButton.ClickEvent event) {
+        switch (event.getComponent().getName().toLowerCase()) {
+            case "button.close":
+                close();
+                break;
+        }
+    }
+
+    private static String getFormattedString(String raw, int length, String suffix) {
+        if (raw.trim().length() <= length) {
+            return raw;
+        } else {
+            return raw.substring(0, Math.min(raw.length(), length)).trim() + suffix;
+        }
+    }
+}

--- a/src/main/java/com/almuradev/almura/client/gui/menu/AlmuraAboutMenu.java
+++ b/src/main/java/com/almuradev/almura/client/gui/menu/AlmuraAboutMenu.java
@@ -110,7 +110,7 @@ public class AlmuraAboutMenu extends AlmuraBackgroundGui {
                 mc.displayGuiScreen(new GuiModList(this));
                 break;
             case "button.close":
-                displayParent();
+                close();
                 break;
         }
     }

--- a/src/main/java/com/almuradev/almura/client/gui/menu/AlmuraConfigurationMenu.java
+++ b/src/main/java/com/almuradev/almura/client/gui/menu/AlmuraConfigurationMenu.java
@@ -221,7 +221,7 @@ public class AlmuraConfigurationMenu extends AlmuraBackgroundGui {
                 setOptimizedConfig();
                 break;
             case "button.cancel":
-                displayParent();
+                close();
                 break;
             case "button.save":
                 try {
@@ -236,7 +236,7 @@ public class AlmuraConfigurationMenu extends AlmuraBackgroundGui {
                 } catch (ConfigurationException e) {
                     e.printStackTrace();
                 }
-                displayParent();
+                close();
         }
     }
 

--- a/src/main/java/com/almuradev/almura/client/gui/menu/AlmuraConfirmMenu.java
+++ b/src/main/java/com/almuradev/almura/client/gui/menu/AlmuraConfirmMenu.java
@@ -88,7 +88,7 @@ public class AlmuraConfirmMenu extends AlmuraBackgroundGui {
     public void onButtonClick(UIButton.ClickEvent event) {
         switch (event.getComponent().getName().toLowerCase()) {
             case "button.close":
-                displayParent();
+                close();
                 break;
         }
     }

--- a/src/main/java/com/almuradev/almura/client/gui/menu/AlmuraServerMenu.java
+++ b/src/main/java/com/almuradev/almura/client/gui/menu/AlmuraServerMenu.java
@@ -129,7 +129,7 @@ public class AlmuraServerMenu extends AlmuraBackgroundGui {
                 mc.displayGuiScreen(new GuiMultiplayer(this));
                 break;
             case "button.back":
-                displayParent();
+                close();
         }
     }
 }

--- a/src/main/java/com/almuradev/almura/items/AlmuraItem.java
+++ b/src/main/java/com/almuradev/almura/items/AlmuraItem.java
@@ -1,0 +1,69 @@
+/**
+ * This file is part of Almura, All Rights Reserved.
+ *
+ * Copyright (c) 2014 AlmuraDev <http://github.com/AlmuraDev/>
+ */
+package com.almuradev.almura.items;
+
+import com.almuradev.almura.Almura;
+import com.almuradev.almura.client.ExternalIcon;
+import com.almuradev.almura.lang.LanguageRegistry;
+import com.almuradev.almura.lang.Languages;
+import com.almuradev.almura.pack.IPackObject;
+import com.almuradev.almura.pack.Pack;
+import cpw.mods.fml.common.registry.GameRegistry;
+import cpw.mods.fml.relauncher.Side;
+import cpw.mods.fml.relauncher.SideOnly;
+import net.minecraft.client.renderer.texture.IIconRegister;
+import net.minecraft.client.renderer.texture.TextureMap;
+import net.minecraft.creativetab.CreativeTabs;
+import net.minecraft.item.Item;
+
+public class AlmuraItem extends Item implements IPackObject {
+
+    /**
+     * Creates an item that that registers the name (in ENGLISH_AMERICAN) and registers the item in the game registry.
+     *
+     * @param unlocalizedName the unlocalized name
+     * @param displayName the localized english american name
+     * @param textureName the texture name
+     */
+    public AlmuraItem(String unlocalizedName, String displayName, String textureName) {
+        this(unlocalizedName, displayName, textureName, null);
+    }
+
+    /**
+     * Creates an item that that registers the name (in ENGLISH_AMERICAN) and registers the item in the game registry.
+     * This also sets the creative tab.
+     *
+     * @param unlocalizedName the unlocalized name
+     * @param displayName the localized english american name
+     * @param textureName the texture name
+     * @param creativeTab the creative tab
+     */
+    public AlmuraItem(String unlocalizedName, String displayName, String textureName, CreativeTabs creativeTab) {
+        setUnlocalizedName(unlocalizedName);
+        setTextureName(Almura.MOD_ID + ":internal/items/" + textureName);
+        LanguageRegistry.put(Languages.ENGLISH_AMERICAN, getUnlocalizedName() + ".name", displayName);
+        if (creativeTab != null) {
+            setCreativeTab(creativeTab);
+        }
+        GameRegistry.registerItem(this, unlocalizedName.replace(".", "\\"));
+    }
+
+    @Override
+    @SideOnly(Side.CLIENT)
+    public void registerIcons(IIconRegister register) {
+        itemIcon = new ExternalIcon(getIconString()).register((TextureMap) register);
+    }
+
+    @Override
+    public Pack getPack() {
+        return Almura.INTERNAL_PACK;
+    }
+
+    @Override
+    public String getIdentifier() {
+        return getUnlocalizedName();
+    }
+}

--- a/src/main/java/com/almuradev/almura/items/Items.java
+++ b/src/main/java/com/almuradev/almura/items/Items.java
@@ -1,0 +1,26 @@
+/**
+ * This file is part of Almura, All Rights Reserved.
+ *
+ * Copyright (c) 2014 AlmuraDev <http://github.com/AlmuraDev/>
+ */
+package com.almuradev.almura.items;
+
+import com.almuradev.almura.items.wands.ExplosionWand;
+import com.almuradev.almura.items.wands.FireballWand;
+import com.almuradev.almura.items.wands.InformationWand;
+import com.almuradev.almura.items.wands.LightningWand;
+import com.almuradev.almura.items.wands.MetadataWand;
+import com.almuradev.almura.tabs.Tabs;
+
+public class Items {
+
+    public static final ExplosionWand WAND_EXPLOSION = new ExplosionWand("wand.explosion", "Explosion Wand", "explosion_wand", Tabs.TAB_TOOLS, 5);
+    public static final FireballWand WAND_FIREBALL = new FireballWand("wand.fireball", "Fireball Wand", "fireball_wand", Tabs.TAB_TOOLS);
+    public static final InformationWand WAND_INFORMATION = new InformationWand("wand.information", "Information Wand", "information_wand", Tabs.TAB_TOOLS);
+    public static final LightningWand WAND_LIGHTNING = new LightningWand("wand.lightning", "Lightning Wand", "lightning_wand", Tabs.TAB_TOOLS);
+    public static final MetadataWand WAND_METADATA = new MetadataWand("wand.metadata", "Metadata Wand", "metadata_wand", Tabs.TAB_TOOLS);
+    public static final ExplosionWand WAND_NUCLEAR = new ExplosionWand("wand.nuclear", "Nuclear Wand", "nuclear_wand", Tabs.TAB_TOOLS, 60);
+
+    public static void fakeStaticLoad() {
+    }
+}

--- a/src/main/java/com/almuradev/almura/items/wands/ExplosionWand.java
+++ b/src/main/java/com/almuradev/almura/items/wands/ExplosionWand.java
@@ -1,0 +1,71 @@
+/**
+ * This file is part of Almura, All Rights Reserved.
+ *
+ * Copyright (c) 2014 AlmuraDev <http://github.com/AlmuraDev/>
+ */
+package com.almuradev.almura.items.wands;
+
+import com.almuradev.almura.items.AlmuraItem;
+import net.minecraft.creativetab.CreativeTabs;
+import net.minecraft.entity.player.EntityPlayer;
+import net.minecraft.entity.player.EntityPlayerMP;
+import net.minecraft.item.ItemStack;
+import net.minecraft.nbt.NBTTagCompound;
+import net.minecraft.network.play.server.S0BPacketAnimation;
+import net.minecraft.util.ChatComponentText;
+import net.minecraft.world.World;
+import net.minecraftforge.common.MinecraftForge;
+import net.minecraftforge.event.entity.player.PlayerInteractEvent;
+
+import java.text.DecimalFormat;
+
+public class ExplosionWand extends AlmuraItem {
+
+    private static final DecimalFormat DECIMAL_FORMAT = new DecimalFormat("#.##");
+    private final float explosionStrength;
+
+    public ExplosionWand(String unlocalizedName, String displayName, String textureName, CreativeTabs creativeTab, float explosionStrength) {
+        super(unlocalizedName, displayName, textureName, creativeTab);
+        this.explosionStrength = explosionStrength;
+    }
+
+    @Override
+    public ItemStack onItemRightClick(ItemStack itemStack, World world, EntityPlayer player) {
+        if (!world.isRemote) {
+            // Fire PlayerInteractEvent
+            final PlayerInteractEvent event = new PlayerInteractEvent(player, PlayerInteractEvent.Action.RIGHT_CLICK_AIR, (int) player.posX,
+                                                                      (int) player.posY, (int) player.posZ, -1, world);
+            MinecraftForge.EVENT_BUS.post(event);
+
+            // Return if the event was cancelled
+            if (event.isCanceled()) {
+                return itemStack;
+            }
+
+            ((EntityPlayerMP) player).playerNetServerHandler.sendPacket(new S0BPacketAnimation(player, 0));
+            player.swingItem();
+
+            if (itemStack.stackTagCompound == null) {
+                itemStack.stackTagCompound = new NBTTagCompound();
+            }
+
+            if (!itemStack.stackTagCompound.getBoolean("primed")) {
+                itemStack.stackTagCompound.setDouble("posX", player.posX);
+                itemStack.stackTagCompound.setDouble("posY", player.posY);
+                itemStack.stackTagCompound.setDouble("posZ", player.posZ);
+                itemStack.stackTagCompound.setBoolean("primed", true);
+                player.addChatComponentMessage(new ChatComponentText(String.format("Primed detonation at [%1$s] [%2$s] [%3$s]",
+                                                                                   DECIMAL_FORMAT.format(player.posX),
+                                                                                   DECIMAL_FORMAT.format(player.posY),
+                                                                                   DECIMAL_FORMAT.format(player.posZ))));
+            } else {
+                world.createExplosion(player, itemStack.getTagCompound().getDouble("posX"),
+                                      itemStack.getTagCompound().getDouble("posY"),
+                                      itemStack.getTagCompound().getDouble("posZ"), explosionStrength, true);
+                itemStack.stackTagCompound.setBoolean("primed", false);
+                player.addChatComponentMessage(new ChatComponentText("Detonation! You can now set a new prime location."));
+            }
+        }
+        return itemStack;
+    }
+}

--- a/src/main/java/com/almuradev/almura/items/wands/FireballWand.java
+++ b/src/main/java/com/almuradev/almura/items/wands/FireballWand.java
@@ -1,0 +1,59 @@
+/**
+ * This file is part of Almura, All Rights Reserved.
+ *
+ * Copyright (c) 2014 AlmuraDev <http://github.com/AlmuraDev/>
+ */
+package com.almuradev.almura.items.wands;
+
+import com.almuradev.almura.items.AlmuraItem;
+import net.minecraft.creativetab.CreativeTabs;
+import net.minecraft.entity.player.EntityPlayer;
+import net.minecraft.entity.player.EntityPlayerMP;
+import net.minecraft.entity.projectile.EntityLargeFireball;
+import net.minecraft.item.ItemStack;
+import net.minecraft.network.play.server.S0BPacketAnimation;
+import net.minecraft.util.Vec3;
+import net.minecraft.world.World;
+import net.minecraftforge.common.MinecraftForge;
+import net.minecraftforge.event.entity.player.PlayerInteractEvent;
+
+public class FireballWand extends AlmuraItem {
+
+    public FireballWand(String unlocalizedName, String displayName, String textureName, CreativeTabs creativeTab) {
+        super(unlocalizedName, displayName, textureName, creativeTab);
+    }
+
+    @Override
+    public ItemStack onItemRightClick(ItemStack itemStack, World world, EntityPlayer player) {
+        if (!world.isRemote) {
+            // Fire PlayerInteractEvent
+            final PlayerInteractEvent
+                    event =
+                    new PlayerInteractEvent(player, PlayerInteractEvent.Action.RIGHT_CLICK_AIR, (int) player.posX, (int) player.posY,
+                                            (int) player.posZ, -1, world);
+            MinecraftForge.EVENT_BUS.post(event);
+
+            // Return if the event was cancelled
+            if (event.isCanceled()) {
+                return itemStack;
+            }
+
+            ((EntityPlayerMP) player).playerNetServerHandler.sendPacket(new S0BPacketAnimation(player, 0));
+            player.swingItem();
+
+            world.playAuxSFXAtEntity(null, 1008, (int) player.posX, (int) player.posY, (int) player.posZ, 0);
+            final Vec3 look = player.getLookVec();
+            final EntityLargeFireball fireball = new EntityLargeFireball(world, player, 1, 1, 1);
+            fireball.setPosition(player.posX + look.xCoord,
+                                 player.posY + look.yCoord + 1,
+                                 player.posZ + look.zCoord);
+            fireball.accelerationX = look.xCoord * 0.1;
+            fireball.accelerationY = look.yCoord * 0.1;
+            fireball.accelerationZ = look.zCoord * 0.1;
+
+            world.spawnEntityInWorld(fireball);
+        }
+
+        return itemStack;
+    }
+}

--- a/src/main/java/com/almuradev/almura/items/wands/InformationWand.java
+++ b/src/main/java/com/almuradev/almura/items/wands/InformationWand.java
@@ -1,0 +1,56 @@
+/**
+ * This file is part of Almura, All Rights Reserved.
+ *
+ * Copyright (c) 2014 AlmuraDev <http://github.com/AlmuraDev/>
+ */
+package com.almuradev.almura.items.wands;
+
+import com.almuradev.almura.client.gui.ingame.IngameBlockInformation;
+import com.almuradev.almura.items.AlmuraItem;
+import net.minecraft.block.Block;
+import net.minecraft.client.Minecraft;
+import net.minecraft.creativetab.CreativeTabs;
+import net.minecraft.entity.player.EntityPlayer;
+import net.minecraft.entity.player.EntityPlayerMP;
+import net.minecraft.item.ItemStack;
+import net.minecraft.network.play.server.S0BPacketAnimation;
+import net.minecraft.world.World;
+import net.minecraftforge.common.MinecraftForge;
+import net.minecraftforge.event.entity.player.PlayerInteractEvent;
+
+public class InformationWand extends AlmuraItem {
+
+    public InformationWand(String unlocalizedName, String displayName, String textureName, CreativeTabs creativeTab) {
+        super(unlocalizedName, displayName, textureName, creativeTab);
+    }
+
+    @Override
+    public boolean onItemUse(ItemStack itemStack, EntityPlayer player, World world, int x, int y, int z, int side, float pointX, float pointY,
+                             float pointZ) {
+        if (!world.isRemote) {
+            // Fire PlayerInteractEvent
+            final PlayerInteractEvent
+                    event =
+                    new PlayerInteractEvent(player, PlayerInteractEvent.Action.RIGHT_CLICK_AIR, (int) player.posX, (int) player.posY,
+                                            (int) player.posZ, -1, world);
+            MinecraftForge.EVENT_BUS.post(event);
+
+            // Return if the event was cancelled
+            if (event.isCanceled()) {
+                return false;
+            }
+
+            final Block block = world.getBlock(x, y, z);
+            final int metadata = world.getBlockMetadata(x, y, z);
+            final ItemStack stack = new ItemStack(block, 1, metadata);
+
+            if (block != null) {
+                ((EntityPlayerMP) player).playerNetServerHandler.sendPacket(new S0BPacketAnimation(player, 0));
+                player.swingItem();
+                Minecraft.getMinecraft()
+                        .displayGuiScreen(new IngameBlockInformation(null, block, stack, metadata, block.getBlockHardness(world, x, y, z)));
+            }
+        }
+        return false;
+    }
+}

--- a/src/main/java/com/almuradev/almura/items/wands/LightningWand.java
+++ b/src/main/java/com/almuradev/almura/items/wands/LightningWand.java
@@ -1,0 +1,76 @@
+/**
+ * This file is part of Almura, All Rights Reserved.
+ *
+ * Copyright (c) 2014 AlmuraDev <http://github.com/AlmuraDev/>
+ */
+package com.almuradev.almura.items.wands;
+
+import com.almuradev.almura.items.AlmuraItem;
+import net.minecraft.creativetab.CreativeTabs;
+import net.minecraft.entity.effect.EntityLightningBolt;
+import net.minecraft.entity.player.EntityPlayer;
+import net.minecraft.entity.player.EntityPlayerMP;
+import net.minecraft.item.ItemStack;
+import net.minecraft.network.play.server.S0BPacketAnimation;
+import net.minecraft.util.MathHelper;
+import net.minecraft.util.MovingObjectPosition;
+import net.minecraft.util.Vec3;
+import net.minecraft.world.World;
+import net.minecraftforge.common.MinecraftForge;
+import net.minecraftforge.event.entity.player.PlayerInteractEvent;
+
+public class LightningWand extends AlmuraItem {
+
+    public LightningWand(String unlocalizedName, String displayName, String textureName, CreativeTabs creativeTab) {
+        super(unlocalizedName, displayName, textureName, creativeTab);
+    }
+
+    @Override
+    public ItemStack onItemRightClick(ItemStack itemStack, World world, EntityPlayer player) {
+        if (!world.isRemote) {
+            // Fire PlayerInteractEvent
+            final PlayerInteractEvent
+                    event =
+                    new PlayerInteractEvent(player, PlayerInteractEvent.Action.RIGHT_CLICK_AIR, (int) player.posX, (int) player.posY,
+                                            (int) player.posZ, -1, world);
+            MinecraftForge.EVENT_BUS.post(event);
+
+            // Return if the event was cancelled
+            if (event.isCanceled()) {
+                return itemStack;
+            }
+
+            ((EntityPlayerMP) player).playerNetServerHandler.sendPacket(new S0BPacketAnimation(player, 0));
+            player.swingItem();
+
+            final MovingObjectPosition objectMouseOver = getDistanceFromPlayer(world, player, true);
+            if (objectMouseOver != null && objectMouseOver.typeOfHit == MovingObjectPosition.MovingObjectType.BLOCK) {
+                world.addWeatherEffect(new EntityLightningBolt(world, objectMouseOver.blockX, objectMouseOver.blockY, objectMouseOver.blockZ));
+            }
+        }
+
+        return itemStack;
+    }
+
+    private MovingObjectPosition getDistanceFromPlayer(World world, EntityPlayer player, boolean bool) {
+        float f = 1.0F;
+        float f1 = player.prevRotationPitch + (player.rotationPitch - player.prevRotationPitch) * f;
+        float f2 = player.prevRotationYaw + (player.rotationYaw - player.prevRotationYaw) * f;
+        double d0 = player.prevPosX + (player.posX - player.prevPosX) * (double) f;
+        // isRemote check to revert changes to ray trace position due to adding the eye height clientside and player yOffset differences
+        double d1 = player.prevPosY + (player.posY - player.prevPosY) * (double) f + (double) (world.isRemote ? player.getEyeHeight() - player
+                .getDefaultEyeHeight() : player.getEyeHeight());
+        double d2 = player.prevPosZ + (player.posZ - player.prevPosZ) * (double) f;
+        Vec3 vec3 = Vec3.createVectorHelper(d0, d1, d2);
+        float f3 = MathHelper.cos(-f2 * 0.017453292F - (float) Math.PI);
+        float f4 = MathHelper.sin(-f2 * 0.017453292F - (float) Math.PI);
+        float f5 = -MathHelper.cos(-f1 * 0.017453292F);
+        float f6 = MathHelper.sin(-f1 * 0.017453292F);
+        float f7 = f4 * f5;
+        float f8 = f3 * f5;
+        double reachDistance = 20.0D;
+
+        Vec3 vec31 = vec3.addVector((double) f7 * reachDistance, (double) f6 * reachDistance, (double) f8 * reachDistance);
+        return world.func_147447_a(vec3, vec31, bool, !bool, false);
+    }
+}

--- a/src/main/java/com/almuradev/almura/items/wands/MetadataWand.java
+++ b/src/main/java/com/almuradev/almura/items/wands/MetadataWand.java
@@ -1,0 +1,86 @@
+/**
+ * This file is part of Almura, All Rights Reserved.
+ *
+ * Copyright (c) 2014 AlmuraDev <http://github.com/AlmuraDev/>
+ */
+package com.almuradev.almura.items.wands;
+
+import com.almuradev.almura.items.AlmuraItem;
+import com.almuradev.almura.pack.crop.PackCrops;
+import net.minecraft.block.Block;
+import net.minecraft.block.BlockCrops;
+import net.minecraft.block.BlockStem;
+import net.minecraft.creativetab.CreativeTabs;
+import net.minecraft.entity.player.EntityPlayer;
+import net.minecraft.entity.player.EntityPlayerMP;
+import net.minecraft.init.Blocks;
+import net.minecraft.item.ItemStack;
+import net.minecraft.network.play.server.S0BPacketAnimation;
+import net.minecraft.util.ChatComponentText;
+import net.minecraft.world.World;
+import net.minecraftforge.common.MinecraftForge;
+import net.minecraftforge.event.entity.player.PlayerInteractEvent;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public class MetadataWand extends AlmuraItem {
+
+    public MetadataWand(String unlocalizedName, String displayName, String textureName, CreativeTabs creativeTab) {
+        super(unlocalizedName, displayName, textureName, creativeTab);
+    }
+
+    @Override
+    public boolean onItemUse(ItemStack itemStack, EntityPlayer player, World world, int x, int y, int z, int side, float pointX, float pointY,
+                             float pointZ) {
+        if (!world.isRemote) {
+            if (world.getBlock(x, y, z) == Blocks.air) {
+                return false;
+            }
+
+            // Fire PlayerInteractEvent
+            final PlayerInteractEvent
+                    event =
+                    new PlayerInteractEvent(player, PlayerInteractEvent.Action.RIGHT_CLICK_AIR, (int) player.posX, (int) player.posY,
+                                            (int) player.posZ, -1, world);
+            MinecraftForge.EVENT_BUS.post(event);
+
+            // Return if the event was cancelled
+            if (event.isCanceled()) {
+                return false;
+            }
+
+            final Block block = world.getBlock(x, y, z);
+            final int maxMetadataValue;
+            if (block instanceof PackCrops) {
+                maxMetadataValue = ((PackCrops) block).getStages().size() - 1;
+            } else if (block instanceof BlockCrops || block instanceof BlockStem) {
+                maxMetadataValue = 7;
+            } else {
+                // Why Mojang?
+                final List list = new ArrayList();
+                world.getBlock(x, y, z).getSubBlocks(null, null, list);
+                maxMetadataValue = list.size() - 1;
+            }
+
+            // If the max data is 0 then we have no variants of this block
+            if (maxMetadataValue == 0) {
+                return false;
+            }
+
+            ((EntityPlayerMP) player).playerNetServerHandler.sendPacket(new S0BPacketAnimation(player, 0));
+            player.swingItem();
+
+            final int currentDataValue = world.getBlockMetadata(x, y, z);
+
+            // If we're at the max metadata value, rollover to 0
+            world.setBlockMetadataWithNotify(x, y, z, currentDataValue == maxMetadataValue ? 0 : currentDataValue + 1, 1);
+
+            // Send a message to the player
+            player.addChatComponentMessage(new ChatComponentText(
+                    String.format("Metadata was changed from [%1$s] to [%2$s].", currentDataValue, world.getBlockMetadata(x, y, z))));
+            return true;
+        }
+        return false;
+    }
+}


### PR DESCRIPTION
- Added Explosion wand.
  First right-click sets the place to detonation an explosion. Second
  right-click creates the explosion and clears the detonation coordinates.
- Added Fireball wand.
  Right-click fires a large fireball that causes explosions and fire upon
  impact.
- Added Information wand.
  Right-click most blocks to see basic details about them.
- Added Lightning wand.
  Right-click to fire lightning at whatever block you are looking at
  within range.
- Added Metadata wand.
  Right-click any block that has multiple subblocks to rotate it through
  the list of those subblocks.
- Added Nuclear wand.
  Essentially an 'Explosion' wand with a much bigger range.

This pull request is linked with https://github.com/AlmuraDev/Almura-2.0-ContentPacks/pull/5

Signed-off-by: Steven Downer grinch@outlook.com
