### PR TITLE
Add LESS (Lightweight Essential Survival Screen) HUD

### DIFF
--- a/src/main/java/com/almuradev/almura/Configuration.java
+++ b/src/main/java/com/almuradev/almura/Configuration.java
@@ -21,7 +21,7 @@ public class Configuration {
     public static final boolean IS_SERVER = FMLCommonHandler.instance().getEffectiveSide().isServer();
     public static final boolean IS_CLIENT = FMLCommonHandler.instance().getEffectiveSide().isClient();
     private static final Object[] PATH_CLIENT_FIRST_LAUNCH = new String[]{"client", "first-launch"};
-    private static final Object[] PATH_CLIENT_ENHANCED_GUI = new String[]{"client", "enhanced-gui"};
+    private static final Object[] PATH_CLIENT_HUD_TYPE = new String[]{"client", "hud-type"};
     private static final Object[] PATH_CLIENT_ENHANCED_DEBUG = new String[]{"client", "enhanced-debug"};
     private static final Object[] PATH_CLIENT_RESIDENCE_HUD = new String[]{"client", "residence-hud"};
     private static final Object[] PATH_CLIENT_ANIMAL_HEAT = new String[]{"client", "animal-heat"};
@@ -41,7 +41,7 @@ public class Configuration {
     public static boolean DEBUG_PACKS;
     public static boolean DEBUG_RECIPES;
     //GUI
-    public static boolean DISPLAY_ENHANCED_GUI = true;
+    public static String HUD_TYPE = "Almura";
     public static boolean DISPLAY_RESIDENCE_HUD = true;
     public static boolean DISPLAY_ANIMAL_HEAT = false;
     public static boolean DISPLAY_ENHANCED_DEBUG = true;
@@ -63,7 +63,7 @@ public class Configuration {
 
         FIRST_LAUNCH = root.getNode(PATH_CLIENT_FIRST_LAUNCH).getBoolean(true);
 
-        DISPLAY_ENHANCED_GUI = root.getNode(PATH_CLIENT_ENHANCED_GUI).getBoolean(true);
+        HUD_TYPE = root.getNode(PATH_CLIENT_HUD_TYPE).getString("Almura");
 
         DISPLAY_ENHANCED_DEBUG = root.getNode(PATH_CLIENT_ENHANCED_DEBUG).getBoolean(true);
 
@@ -91,7 +91,7 @@ public class Configuration {
     }
 
     public static void save() throws IOException {
-        root.getNode(PATH_CLIENT_ENHANCED_GUI).setValue(DISPLAY_ENHANCED_GUI);
+        root.getNode(PATH_CLIENT_HUD_TYPE).setValue(HUD_TYPE);
 
         root.getNode(PATH_CLIENT_ENHANCED_DEBUG).setValue(DISPLAY_ENHANCED_DEBUG);
 
@@ -149,8 +149,8 @@ public class Configuration {
         mc.gameSettings.saveOptions();
     }
 
-    public static void toggleEnhancedGUI(boolean value) {
-        DISPLAY_ENHANCED_GUI = value;
+    public static void setHUDType(String value) {
+        HUD_TYPE = value;
     }
 
     public static void toggleResidenceHUD(boolean value) {

--- a/src/main/java/com/almuradev/almura/client/gui/ingame/hud/IngameAlmuraHUD.java
+++ b/src/main/java/com/almuradev/almura/client/gui/ingame/hud/IngameAlmuraHUD.java
@@ -3,9 +3,10 @@
  *
  * Copyright (c) 2014 AlmuraDev <http://github.com/AlmuraDev/>
  */
-package com.almuradev.almura.client.gui.ingame;
+package com.almuradev.almura.client.gui.ingame.hud;
 
 import com.almuradev.almura.client.FontRenderOptionsConstants;
+import com.almuradev.almura.client.gui.ingame.HUDData;
 import com.almuradev.almurasdk.client.gui.SimpleGui;
 import com.almuradev.almurasdk.client.gui.components.UIPropertyBar;
 import com.almuradev.almurasdk.util.Colors;
@@ -22,7 +23,7 @@ import net.minecraft.server.MinecraftServer;
 import net.minecraftforge.common.ForgeHooks;
 import org.apache.commons.lang3.text.WordUtils;
 
-public class IngameHUD extends SimpleGui {
+public class IngameAlmuraHUD extends SimpleGui {
 
     private static final String COMPASS_CHARACTERS = "S|.|W|.|N|.|E|.|";
     private final UIBackgroundContainer gradientContainer = new UIBackgroundContainer(this);
@@ -268,7 +269,7 @@ public class IngameHUD extends SimpleGui {
         return gradientContainer;
     }
 
-    // This is to fix the GUI Lighting issue that exists between Almura and Optifine & ShadersMod. 
+    // This is to fix the GUI Lighting issue that exists between Almura and Optifine & ShadersMod.
     // Something about the change that Ordi made with the "disable backgroundGUI causes a conflict if our screens render here.
 
     @Override

--- a/src/main/java/com/almuradev/almura/client/gui/ingame/hud/IngameLessHUD.java
+++ b/src/main/java/com/almuradev/almura/client/gui/ingame/hud/IngameLessHUD.java
@@ -1,0 +1,171 @@
+/**
+ * This file is part of Almura, All Rights Reserved.
+ *
+ * Copyright (c) 2014 AlmuraDev <http://github.com/AlmuraDev/>
+ */
+package com.almuradev.almura.client.gui.ingame.hud;
+
+import com.almuradev.almura.client.gui.ingame.HUDData;
+import com.almuradev.almurasdk.client.gui.SimpleGui;
+import com.almuradev.almurasdk.util.Colors;
+import com.almuradev.almurasdk.util.FontRenderOptionsBuilder;
+import cpw.mods.fml.client.FMLClientHandler;
+import net.malisis.core.client.gui.Anchor;
+import net.malisis.core.client.gui.component.UIComponent;
+import net.malisis.core.client.gui.component.container.UIBackgroundContainer;
+import net.malisis.core.client.gui.component.decoration.UIImage;
+import net.malisis.core.client.gui.component.decoration.UILabel;
+import net.malisis.core.renderer.font.FontRenderOptions;
+import net.minecraft.client.Minecraft;
+import net.minecraft.client.gui.GuiChat;
+
+public class IngameLessHUD extends SimpleGui {
+
+    private static final FontRenderOptions FRO_HUD;
+    private static final int PADDING = 1;
+    private static final String COMPASS_CHARACTERS = "S.......W.......N.......E.......";
+    private static final String TIME_FORMAT = "%2d:%02d%s";
+    private UIBackgroundContainer clockContainer, compassContainer, coordinatesContainer, overlayContainer;
+    private UILabel clockLabel, economyLabel, compassLabel, coordinatesXLabel, coordinatesYLabel, coordinatesZLabel, nameLabel, worldLabel;
+    private UIImage armorImage, clockImage, experienceImage, healthImage, staminaImage;
+
+    static {
+        FRO_HUD = new FontRenderOptions();
+        FRO_HUD.color = Colors.WHITE.getGuiColorCode();
+        FRO_HUD.shadow = true;
+    }
+
+    @Override
+    public void construct() {
+        guiscreenBackground = false;
+
+        overlayContainer = new UIBackgroundContainer(this, UIComponent.INHERITED, UIComponent.INHERITED);
+        overlayContainer.setBackgroundAlpha(0);
+        overlayContainer.setClipContent(false);
+
+        // Display name
+        nameLabel = new UILabel(this, mc.thePlayer.getDisplayName());
+        nameLabel.setPosition(PADDING, PADDING, Anchor.TOP | Anchor.LEFT);
+        nameLabel.setFontRenderOptions(FRO_HUD);
+
+        // Economy
+        economyLabel = new UILabel(this, "$0.00");
+        economyLabel.setPosition(PADDING, getPaddedY(nameLabel, PADDING), Anchor.TOP | Anchor.LEFT);
+        economyLabel.setFontRenderOptions(FRO_HUD);
+
+        // Clock
+        clockImage = new UIImage(this, TEXTURE_SPRITESHEET, ICON_CLOCK);
+        clockImage.setPosition(PADDING, getPaddedY(economyLabel, PADDING), Anchor.TOP | Anchor.LEFT);
+        clockImage.setSize(7, 7);
+
+        clockLabel = new UILabel(this, "12:00AM");
+        clockLabel.setPosition(getPaddedX(clockImage, PADDING), getPaddedY(economyLabel, PADDING), clockImage.getAnchor());
+        clockLabel.setFontRenderOptions(FRO_HUD);
+
+        // Compass
+        compassContainer = new UIBackgroundContainer(this, 50, 10);
+        compassContainer.setBackgroundAlpha(180);
+        compassContainer.setColor(0);
+        compassContainer.setPosition(0, 0, Anchor.TOP | Anchor.CENTER);
+
+        compassLabel = new UILabel(this, "");
+        compassLabel.setPosition(1, 1, Anchor.CENTER | Anchor.MIDDLE);
+        compassLabel.setFontRenderOptions(FontRenderOptionsBuilder.builder().from(FRO_HUD).shadow(false).build());
+
+        compassContainer.add(compassLabel);
+
+        // World
+        worldLabel = new UILabel(this, "World");
+        worldLabel.setPosition(0, getPaddedY(compassContainer, PADDING), Anchor.TOP | Anchor.CENTER);
+        worldLabel.setFontRenderOptions(FRO_HUD);
+
+        // Coordinates
+        coordinatesXLabel = new UILabel(this, (int) mc.thePlayer.posX + " X");
+        coordinatesXLabel.setPosition(-PADDING, PADDING, Anchor.TOP | Anchor.RIGHT);
+        coordinatesXLabel.setFontRenderOptions(FRO_HUD);
+
+        coordinatesYLabel = new UILabel(this, (int) mc.thePlayer.posY + " Y");
+        coordinatesYLabel.setPosition(-PADDING, getPaddedY(coordinatesXLabel, PADDING), Anchor.TOP | Anchor.RIGHT);
+        coordinatesYLabel.setFontRenderOptions(FRO_HUD);
+
+        coordinatesZLabel = new UILabel(this, (int) mc.thePlayer.posZ + " Z");
+        coordinatesZLabel.setPosition(-PADDING, getPaddedY(coordinatesYLabel, PADDING), Anchor.TOP | Anchor.RIGHT);
+        coordinatesZLabel.setFontRenderOptions(FRO_HUD);
+
+        overlayContainer.add(nameLabel, economyLabel, clockImage, clockLabel, compassContainer, worldLabel, coordinatesXLabel, coordinatesYLabel,
+                coordinatesZLabel);
+
+        addToScreen(overlayContainer);
+    }
+
+    @Override
+    public void update(int mouseX, int mouseY, float partialTick) {
+        // Clock
+        clockLabel.setText(getTime());
+
+        // Compass
+        compassLabel.setText(getCompass());
+
+        if (!mc.isSingleplayer()) {
+            // Economy
+            economyLabel.setText(HUDData.PLAYER_CURRENCY);
+
+            // World
+            worldLabel.setText(HUDData.WORLD_DISPLAY);
+        }
+
+        // Coordinates
+        coordinatesXLabel.setText((int) mc.thePlayer.posX + " X");
+        coordinatesYLabel.setText((int) mc.thePlayer.posY + " Y");
+        coordinatesZLabel.setText((int) mc.thePlayer.posZ + " Z");
+    }
+
+    public String getCompass() {
+        final int position = (int) ((((mc.thePlayer.rotationYaw + 11.25) % 360 + 360) % 360) / 360 * 32);
+
+        return "" + Colors.DARK_GRAY + COMPASS_CHARACTERS.charAt((position - 8) & 31)
+                + Colors.DARK_GRAY + COMPASS_CHARACTERS.charAt((position - 7) & 31)
+                + Colors.DARK_GRAY + COMPASS_CHARACTERS.charAt((position - 6) & 31)
+                + Colors.DARK_GRAY + COMPASS_CHARACTERS.charAt((position - 5) & 31)
+                + Colors.DARK_GRAY + COMPASS_CHARACTERS.charAt((position - 4) & 31)
+                + Colors.DARK_GRAY + COMPASS_CHARACTERS.charAt((position - 3) & 31)
+                + Colors.DARK_GRAY + COMPASS_CHARACTERS.charAt((position - 2) & 31)
+                + Colors.GRAY + COMPASS_CHARACTERS.charAt((position - 1) & 31)
+                + Colors.WHITE + COMPASS_CHARACTERS.charAt((position) & 31)
+                + Colors.GRAY + COMPASS_CHARACTERS.charAt((position + 1) & 31)
+                + Colors.DARK_GRAY + COMPASS_CHARACTERS.charAt((position + 2) & 31)
+                + Colors.DARK_GRAY + COMPASS_CHARACTERS.charAt((position + 3) & 31)
+                + Colors.DARK_GRAY + COMPASS_CHARACTERS.charAt((position + 4) & 31)
+                + Colors.DARK_GRAY + COMPASS_CHARACTERS.charAt((position + 5) & 31)
+                + Colors.DARK_GRAY + COMPASS_CHARACTERS.charAt((position + 6) & 31)
+                + Colors.DARK_GRAY + COMPASS_CHARACTERS.charAt((position + 7) & 31)
+                + Colors.DARK_GRAY + COMPASS_CHARACTERS.charAt((position + 8) & 31);
+    }
+
+    public String getTime() {
+        final int minute = (int) Math.floor((mc.thePlayer.worldObj.getWorldTime() % 1000) / 1000.0 * 60);
+        final int hour = (int) ((Math.floor(mc.thePlayer.worldObj.getWorldTime() / 1000.0) + 6) % 24);
+
+        if (hour == 0) {
+            return String.format(TIME_FORMAT, hour + 12, minute, "AM");
+        } else if (hour == 12) {
+            return String.format(TIME_FORMAT, hour, minute, "PM");
+        } else if (hour > 12) {
+            return String.format(TIME_FORMAT, hour - 12, minute, "PM");
+        } else {
+            return String.format(TIME_FORMAT, hour, minute, "AM");
+        }
+    }
+
+    @Override
+    public void drawScreen(int mouseX, int mouseY, float partialTicks) {
+        if (FMLClientHandler.instance().hasOptifine()) {
+            if (Minecraft.getMinecraft().currentScreen != null) {
+                if (!(Minecraft.getMinecraft().currentScreen instanceof GuiChat)) {
+                    return;
+                }
+            }
+        }
+        super.drawScreen(mouseX, mouseY, partialTicks);
+    }
+}

--- a/src/main/java/com/almuradev/almura/client/gui/menu/DynamicConfigurationMenu.java
+++ b/src/main/java/com/almuradev/almura/client/gui/menu/DynamicConfigurationMenu.java
@@ -22,9 +22,8 @@ import java.util.Arrays;
 
 public class DynamicConfigurationMenu extends SimpleGui {
 
-    private UICheckBox almuraGuiCheckBox, residenceHudCheckBox, animalHeatCheckBox, almuraDebugGuiCheckBox, debugModeCheckBox, debugLanguagesCheckBox,
-            debugPacksCheckBox,
-            debugMappingsCheckBox, debugRecipesCheckBox, chatNotificationCheckBox;
+    private UICheckBox residenceHudCheckBox, animalHeatCheckBox, almuraDebugGuiCheckBox, debugModeCheckBox, debugLanguagesCheckBox,
+            debugPacksCheckBox, debugMappingsCheckBox, debugRecipesCheckBox, chatNotificationCheckBox;
 
     public DynamicConfigurationMenu(SimpleGui parent) {
         super(parent);
@@ -39,15 +38,27 @@ public class DynamicConfigurationMenu extends SimpleGui {
 
         final int padding = 4;
 
-        // Create the almura GUI checkbox
-        almuraGuiCheckBox = new UICheckBox(this, Colors.WHITE + "Enhanced In-Game HUD");
-        almuraGuiCheckBox.setPosition(padding, padding * 2, Anchor.LEFT | Anchor.TOP);
-        almuraGuiCheckBox.setChecked(Configuration.DISPLAY_ENHANCED_GUI);
-        almuraGuiCheckBox.setName("checkbox.enhanced_gui");
-        almuraGuiCheckBox.register(this);
+        final UILabel hudTypeLabel = new UILabel(this, Colors.WHITE + "HUD:");
+        hudTypeLabel.setPosition(padding, padding * 2, Anchor.LEFT | Anchor.TOP);
+
+        final UISelect<String> hudTypeSelect = new UISelect<>(this, 50, Arrays.asList("Vanilla", "Almura", "LESS"));
+        hudTypeSelect.setPosition(getPaddedX(hudTypeLabel, padding), hudTypeLabel.getY(), Anchor.LEFT | Anchor.TOP);
+        switch (Configuration.HUD_TYPE.toLowerCase()) {
+            case "almura":
+                hudTypeSelect.select("Almura");
+                break;
+            case "less":
+                hudTypeSelect.select("LESS");
+                break;
+            default:
+                hudTypeSelect.select("Vanilla");
+                break;
+        }
+        hudTypeSelect.setName("select.hud");
+        hudTypeSelect.register(this);
 
         residenceHudCheckBox = new UICheckBox(this, Colors.WHITE + "Residence HUD");
-        residenceHudCheckBox.setPosition(padding, almuraGuiCheckBox.getY() + (padding * 4), Anchor.LEFT | Anchor.TOP);
+        residenceHudCheckBox.setPosition(padding, hudTypeLabel.getY() + (padding * 4), Anchor.LEFT | Anchor.TOP);
         residenceHudCheckBox.setChecked(Configuration.DISPLAY_RESIDENCE_HUD);
         residenceHudCheckBox.setName("checkbox.residence_hud");
         residenceHudCheckBox.register(this);
@@ -62,7 +73,7 @@ public class DynamicConfigurationMenu extends SimpleGui {
         chestRenderDistance.setPosition(-55, padding * 2, Anchor.RIGHT | Anchor.TOP);
 
         final UILabel signRenderDistance = new UILabel(this, Colors.WHITE + "Sign Distance:");
-        signRenderDistance.setPosition(-55, almuraGuiCheckBox.getY() + (padding * 4), Anchor.RIGHT | Anchor.TOP);
+        signRenderDistance.setPosition(-55, hudTypeLabel.getY() + (padding * 4), Anchor.RIGHT | Anchor.TOP);
 
         final UILabel itemFrameRenderDistance = new UILabel(this, Colors.WHITE + "Item Frame Distance:");
         itemFrameRenderDistance.setPosition(-55, signRenderDistance.getY() + (padding * 4), Anchor.RIGHT | Anchor.TOP);
@@ -173,11 +184,10 @@ public class DynamicConfigurationMenu extends SimpleGui {
         backButton.setName("button.back");
         backButton.register(this);
 
-        form.getContentContainer().add(signRenderDistance, itemFrameRenderDistance, chestRenderDistance, almuraGuiCheckBox,
-                residenceHudCheckBox, animalHeatCheckBox,
-                almuraDebugGuiCheckBox, debugModeCheckBox, debugLanguagesCheckBox,
-                debugPacksCheckBox, debugMappingsCheckBox, debugRecipesCheckBox, graphicsButton, backButton, saveButton,
-                chatNotificationCheckBox, itemFrameDistanceDownMenu, signDistanceDownMenu, chestDistanceDownMenu);
+        form.getContentContainer().add(signRenderDistance, itemFrameRenderDistance, chestRenderDistance, residenceHudCheckBox, animalHeatCheckBox,
+                almuraDebugGuiCheckBox, debugModeCheckBox, debugLanguagesCheckBox, debugPacksCheckBox, debugMappingsCheckBox, debugRecipesCheckBox,
+                graphicsButton, backButton, saveButton, chatNotificationCheckBox, itemFrameDistanceDownMenu, signDistanceDownMenu,
+                chestDistanceDownMenu, hudTypeLabel, hudTypeSelect);
 
         if (this.mc.thePlayer == null) {
             addToScreen(new UIAnimatedBackground(this));
@@ -198,7 +208,6 @@ public class DynamicConfigurationMenu extends SimpleGui {
                 break;
             case "button.save":
                 try {
-                    Configuration.toggleEnhancedGUI(almuraGuiCheckBox.isChecked());
                     Configuration.toggleResidenceHUD(residenceHudCheckBox.isChecked());
                     Configuration.toggleAnimalHeat(animalHeatCheckBox.isChecked());
                     Configuration.toggleEnhancedDebug(almuraDebugGuiCheckBox.isChecked());
@@ -229,7 +238,8 @@ public class DynamicConfigurationMenu extends SimpleGui {
             case "select.sign":
                 Configuration.setSignRenderDistance((Integer) event.getNewValue());
                 break;
-
+            case "select.hud":
+                Configuration.setHUDType((String) event.getNewValue());
         }
     }
 }

--- a/src/main/java/com/almuradev/almura/core/mixin/client/gui/MixinGuiIngameForge.java
+++ b/src/main/java/com/almuradev/almura/core/mixin/client/gui/MixinGuiIngameForge.java
@@ -1,0 +1,163 @@
+/**
+ * This file is part of Almura, All Rights Reserved.
+ *
+ * Copyright (c) 2014 AlmuraDev <http://github.com/AlmuraDev/>
+ */
+package com.almuradev.almura.core.mixin.client.gui;
+
+import static net.minecraftforge.client.event.RenderGameOverlayEvent.ElementType.PLAYER_LIST;
+
+import com.almuradev.almura.Configuration;
+import net.minecraft.client.Minecraft;
+import net.minecraft.client.gui.FontRenderer;
+import net.minecraft.client.gui.Gui;
+import net.minecraft.client.gui.GuiIngame;
+import net.minecraft.client.gui.GuiPlayerInfo;
+import net.minecraft.client.gui.ScaledResolution;
+import net.minecraft.client.network.NetHandlerPlayClient;
+import net.minecraft.entity.boss.BossStatus;
+import net.minecraft.scoreboard.Score;
+import net.minecraft.scoreboard.ScoreObjective;
+import net.minecraft.scoreboard.ScorePlayerTeam;
+import net.minecraft.util.EnumChatFormatting;
+import net.minecraftforge.client.GuiIngameForge;
+import net.minecraftforge.client.event.RenderGameOverlayEvent;
+import org.lwjgl.opengl.GL11;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Overwrite;
+import org.spongepowered.asm.mixin.Shadow;
+
+import java.util.List;
+
+@Mixin(value = GuiIngameForge.class, remap = false)
+public abstract class MixinGuiIngameForge extends GuiIngame {
+
+    @Shadow private FontRenderer fontrenderer;
+
+    @Shadow abstract boolean pre(RenderGameOverlayEvent.ElementType type);
+    @Shadow abstract void post(RenderGameOverlayEvent.ElementType type);
+
+    public MixinGuiIngameForge(Minecraft p_i1036_1_) {
+        super(p_i1036_1_);
+    }
+
+    // TODO: Use modify args when Mixin is updated
+    @Overwrite
+    protected void renderBossHealth() {
+        if (BossStatus.bossName != null && BossStatus.statusBarTime > 0)
+        {
+            --BossStatus.statusBarTime;
+            FontRenderer fontrenderer = this.mc.fontRendererObj;
+            ScaledResolution scaledresolution = new ScaledResolution(this.mc, this.mc.displayWidth, this.mc.displayHeight);
+            int i = scaledresolution.getScaledWidth();
+            short short1 = 182;
+            int j = i / 2 - short1 / 2;
+            int k = (int)(BossStatus.healthScale * (float)(short1 + 1));
+            byte b0 = 12;
+            // Almura start - Check for our HUD
+            if (Configuration.HUD_TYPE.equalsIgnoreCase("almura")) {
+                b0 = 45;
+            } else if (Configuration.HUD_TYPE.equalsIgnoreCase("less")) {
+                b0 = 30;
+            }
+            // Almura end
+            this.drawTexturedModalRect(j, b0, 0, 74, short1, 5);
+            this.drawTexturedModalRect(j, b0, 0, 74, short1, 5);
+
+            if (k > 0)
+            {
+                this.drawTexturedModalRect(j, b0, 0, 79, k, 5);
+            }
+
+            String s = BossStatus.bossName;
+            fontrenderer.drawStringWithShadow(s, i / 2 - fontrenderer.getStringWidth(s) / 2, b0 - 10, 16777215);
+            GL11.glColor4f(1.0F, 1.0F, 1.0F, 1.0F);
+            this.mc.getTextureManager().bindTexture(icons);
+        }
+    }
+
+    protected void renderPlayerList(int width, int height)
+    {
+        ScoreObjective scoreobjective = this.mc.theWorld.getScoreboard().getObjectiveInDisplaySlot(0);
+        NetHandlerPlayClient handler = mc.thePlayer.sendQueue;
+
+        if (mc.gameSettings.keyBindPlayerList.getIsKeyPressed() && (!mc.isIntegratedServerRunning() || handler.playerInfoList.size() > 1 || scoreobjective != null))
+        {
+            if (pre(PLAYER_LIST)) return;
+            this.mc.mcProfiler.startSection("playerList");
+            List<GuiPlayerInfo> players = (List<GuiPlayerInfo>)handler.playerInfoList;
+            int maxPlayers = handler.currentServerMaxPlayers;
+            int rows = maxPlayers;
+            int columns = 1;
+
+            for (columns = 1; rows > 20; rows = (maxPlayers + columns - 1) / columns)
+            {
+                columns++;
+            }
+
+            int columnWidth = 300 / columns;
+
+            if (columnWidth > 150)
+            {
+                columnWidth = 150;
+            }
+
+            int left = (width - columns * columnWidth) / 2;
+            byte border = 10;
+            // Almura start - Check for our HUD
+            if (Configuration.HUD_TYPE.equalsIgnoreCase("almura")) {
+                border = 40;
+            } else if (Configuration.HUD_TYPE.equalsIgnoreCase("less")) {
+                border = 25;
+            }
+            // Almura end
+            drawRect(left - 1, border - 1, left + columnWidth * columns, border + 9 * rows, Integer.MIN_VALUE);
+
+            for (int i = 0; i < maxPlayers; i++)
+            {
+                int xPos = left + i % columns * columnWidth;
+                int yPos = border + i / columns * 9;
+                drawRect(xPos, yPos, xPos + columnWidth - 1, yPos + 8, 553648127);
+                GL11.glColor4f(1.0F, 1.0F, 1.0F, 1.0F);
+                GL11.glEnable(GL11.GL_ALPHA_TEST);
+
+                if (i < players.size())
+                {
+                    GuiPlayerInfo player = (GuiPlayerInfo)players.get(i);
+                    ScorePlayerTeam team = mc.theWorld.getScoreboard().getPlayersTeam(player.name);
+                    String displayName = ScorePlayerTeam.formatPlayerName(team, player.name);
+                    fontrenderer.drawStringWithShadow(displayName, xPos, yPos, 16777215);
+
+                    if (scoreobjective != null)
+                    {
+                        int endX = xPos + fontrenderer.getStringWidth(displayName) + 5;
+                        int maxX = xPos + columnWidth - 12 - 5;
+
+                        if (maxX - endX > 5)
+                        {
+                            Score score = scoreobjective.getScoreboard().getValueFromObjective(player.name, scoreobjective);
+                            String scoreDisplay = EnumChatFormatting.YELLOW + "" + score.getScorePoints();
+                            fontrenderer.drawStringWithShadow(scoreDisplay, maxX - fontrenderer.getStringWidth(scoreDisplay), yPos, 16777215);
+                        }
+                    }
+
+                    GL11.glColor4f(1.0F, 1.0F, 1.0F, 1.0F);
+
+                    mc.getTextureManager().bindTexture(Gui.icons);
+                    int pingIndex = 4;
+                    int ping = player.responseTime;
+                    if (ping < 0) pingIndex = 5;
+                    else if (ping < 150) pingIndex = 0;
+                    else if (ping < 300) pingIndex = 1;
+                    else if (ping < 600) pingIndex = 2;
+                    else if (ping < 1000) pingIndex = 3;
+
+                    zLevel += 100.0F;
+                    drawTexturedModalRect(xPos + columnWidth - 12, yPos, 0, 176 + pingIndex * 8, 10, 8);
+                    zLevel -= 100.0F;
+                }
+            }
+            post(PLAYER_LIST);
+        }
+    }
+}

--- a/src/main/resources/mixins.almura.json
+++ b/src/main/resources/mixins.almura.json
@@ -17,6 +17,7 @@
         "client.entity.MixinEntityClientPlayerMP",
         "client.gui.inventory.MixinGuiEditSign",
         "client.gui.MixinGuiChat",
+        "client.gui.MixinGuiIngameForge",
         "client.gui.MixinGuiNewChat",
         "client.renderer.texture.MixinTextureMap",
         "client.renderer.entity.MixinRender",


### PR DESCRIPTION
- Moved IngameHUD to ingame/hud/ package
- Renamed IngameHUD to IngameAlmuraHUD
- Added IngameLessHUD
- Changed the config to use strings for the HUD instead of a boolean. This
  saves when they select it from the dropdown in the configuration screen
  (default is still Almura)
- Added new mixin to move boss bar and player list when custom HUDs are
  shown.

Screenshots: http://imgur.com/zCwADV1,9tde3sK,rS9itUv,wLkLxQU,NADrLwe,nQwXAVZ

Signed-off-by: Steven Downer <grinch@outlook.com>