### PR TITLE
Use api instead of full jar

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -102,7 +102,7 @@ dependencies {
     compile ('com.almuradev:guide:1.7.10-1448-1-SNAPSHOT:dev') {
         transitive = true
     }
-    provided 'net.industrial-craft:industrialcraft-2:2.2.770-experimental:dev'
+    provided 'net.industrial-craft:industrialcraft-2:2.2.770-experimental:api'
 }
 
 processResources {


### PR DESCRIPTION
Faster when building... It seems that `provided` is shipping some code like `shade` in forgegradle document. So is shipping the api more reasonable than shipping the full ic2?