### PR TITLE
Add support for block soundgroups

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -118,6 +118,7 @@ license {
 }
 
 sortClassFields {
+    add 'main', 'com.almuradev.almura.content.block.sound.BlockSoundGroups'
     add 'main', 'com.almuradev.almura.content.item.group.ItemGroups'
     add 'main', 'com.almuradev.almura.content.material.MapColors'
     add 'main', 'com.almuradev.almura.content.material.Materials'

--- a/src/main/java/com/almuradev/almura/CommonProxy.java
+++ b/src/main/java/com/almuradev/almura/CommonProxy.java
@@ -7,19 +7,23 @@ package com.almuradev.almura;
 
 import com.almuradev.almura.configuration.AbstractConfiguration;
 import com.almuradev.almura.configuration.MappedConfigurationAdapter;
+import com.almuradev.almura.content.block.sound.BlockSoundGroup;
 import com.almuradev.almura.content.block.BuildableBlockType;
 import com.almuradev.almura.content.block.builder.AbstractBlockTypeBuilder;
 import com.almuradev.almura.content.block.builder.rotatable.HorizontalTypeBuilderImpl;
 import com.almuradev.almura.content.block.rotatable.HorizontalType;
+import com.almuradev.almura.content.block.sound.BlockSoundGroupBuilder;
 import com.almuradev.almura.content.item.group.ItemGroup;
 import com.almuradev.almura.content.item.group.ItemGroupBuilderImpl;
 import com.almuradev.almura.content.loader.AssetLoader;
+import com.almuradev.almura.content.loader.stage.LoadBlockSoundGroupsStage;
 import com.almuradev.almura.content.loader.stage.LoadItemGroupsStage;
 import com.almuradev.almura.content.loader.stage.LoadMaterialsStage;
 import com.almuradev.almura.content.material.MapColor;
 import com.almuradev.almura.content.material.Material;
 import com.almuradev.almura.network.play.SServerInformationMessage;
 import com.almuradev.almura.network.play.SWorldInformationMessage;
+import com.almuradev.almura.registry.BlockSoundGroupRegistryModule;
 import com.almuradev.almura.registry.ItemGroupRegistryModule;
 import com.almuradev.almura.registry.MapColorRegistryModule;
 import com.almuradev.almura.registry.MaterialRegistryModule;
@@ -93,18 +97,22 @@ public abstract class CommonProxy {
 
     protected void registerModules() {
         final GameRegistry registry = Sponge.getRegistry();
+        registry.registerModule(BlockSoundGroup.class, new BlockSoundGroupRegistryModule());
         registry.registerModule(ItemGroup.class, ItemGroupRegistryModule.getInstance());
         registry.registerModule(MapColor.class, new MapColorRegistryModule());
         registry.registerModule(Material.class, new MaterialRegistryModule());
     }
 
     protected void registerBuilders() {
-        Sponge.getRegistry().registerBuilderSupplier(ItemGroup.Builder.class, ItemGroupBuilderImpl::new);
-        Sponge.getRegistry().registerBuilderSupplier(BuildableBlockType.Builder.class, AbstractBlockTypeBuilder.BuilderImpl::new);
-        Sponge.getRegistry().registerBuilderSupplier(HorizontalType.Builder.class, HorizontalTypeBuilderImpl::new);
+        final GameRegistry registry = Sponge.getRegistry();
+        registry.registerBuilderSupplier(BlockSoundGroup.Builder.class, BlockSoundGroupBuilder::new);
+        registry.registerBuilderSupplier(ItemGroup.Builder.class, ItemGroupBuilderImpl::new);
+        registry.registerBuilderSupplier(BuildableBlockType.Builder.class, AbstractBlockTypeBuilder.BuilderImpl::new);
+        registry.registerBuilderSupplier(HorizontalType.Builder.class, HorizontalTypeBuilderImpl::new);
     }
 
     protected void registerLoaderStages() {
+        this.assetLoader.registerLoaderStage(LoadBlockSoundGroupsStage.INSTANCE);
         this.assetLoader.registerLoaderStage(LoadItemGroupsStage.instance);
         this.assetLoader.registerLoaderStage(LoadMaterialsStage.instance);
     }

--- a/src/main/java/com/almuradev/almura/Constants.java
+++ b/src/main/java/com/almuradev/almura/Constants.java
@@ -87,6 +87,7 @@ public class Constants {
             public static final String MAP_COLOR = "map-color";
             public static final String MATERIAL = "material";
             public static final String RESISTANCE = "resistance";
+            public static final String SOUND_GROUP = "sound-group";
 
             public static final class AABB {
                 public static final String KEY = "aabb";
@@ -94,6 +95,16 @@ public class Constants {
                 public static final String WIREFRAME = "wireframe";
                 public static final String TYPE = "type";
                 public static final String BOX = "box";
+            }
+
+            public static final class SoundGroup {
+                public static final String VOLUME = "volume";
+                public static final String PITCH = "pitch";
+                public static final String BREAK_SOUND = "break-sound";
+                public static final String STEP_SOUND = "step-sound";
+                public static final String PLACE_SOUND = "place-sound";
+                public static final String HIT_SOUND = "hit-sound";
+                public static final String FALL_SOUND = "fall-sound";
             }
         }
 

--- a/src/main/java/com/almuradev/almura/asm/mixin/core/block/MixinSoundType.java
+++ b/src/main/java/com/almuradev/almura/asm/mixin/core/block/MixinSoundType.java
@@ -1,0 +1,35 @@
+/*
+ * This file is part of Almura, All Rights Reserved.
+ *
+ * Copyright (c) AlmuraDev <http://github.com/AlmuraDev/>
+ */
+package com.almuradev.almura.asm.mixin.core.block;
+
+import com.almuradev.almura.asm.mixin.interfaces.IMixinSetCatalogTypeId;
+import com.almuradev.almura.content.block.sound.BlockSoundGroup;
+import net.minecraft.block.SoundType;
+import org.spongepowered.asm.mixin.Mixin;
+
+// remaining BlockSoundGroup methods are implemented in SpongeCommon
+@Mixin(SoundType.class)
+public abstract class MixinSoundType implements BlockSoundGroup, IMixinSetCatalogTypeId {
+
+    private String id;
+    private String name;
+
+    @Override
+    public String getId() {
+        return this.id;
+    }
+
+    @Override
+    public String getName() {
+        return this.name;
+    }
+
+    @Override
+    public void setId(String id, String name) {
+        this.id = id;
+        this.name = name;
+    }
+}

--- a/src/main/java/com/almuradev/almura/content/block/BuildableBlockType.java
+++ b/src/main/java/com/almuradev/almura/content/block/BuildableBlockType.java
@@ -5,12 +5,14 @@
  */
 package com.almuradev.almura.content.block;
 
+import com.almuradev.almura.content.block.sound.BlockSoundGroup;
 import com.almuradev.almura.content.material.MapColor;
 import com.almuradev.almura.content.material.Material;
 import com.almuradev.almura.content.material.MaterialType;
 import org.spongepowered.api.Sponge;
 import org.spongepowered.api.block.BlockType;
 
+import java.util.Optional;
 import java.util.OptionalDouble;
 import java.util.OptionalInt;
 
@@ -54,6 +56,10 @@ public interface BuildableBlockType extends MaterialType, BlockType {
         OptionalDouble resistance();
 
         BUILDER resistance(float resistance);
+
+        Optional<BlockSoundGroup> soundGroup();
+
+        BUILDER soundGroup(BlockSoundGroup group);
 
         @Override
         default BLOCK build(String id, String name) {

--- a/src/main/java/com/almuradev/almura/content/block/builder/AbstractBlockTypeBuilder.java
+++ b/src/main/java/com/almuradev/almura/content/block/builder/AbstractBlockTypeBuilder.java
@@ -10,12 +10,14 @@ import static com.google.common.base.Preconditions.checkState;
 
 import com.almuradev.almura.Constants;
 import com.almuradev.almura.content.block.BlockAABB;
+import com.almuradev.almura.content.block.sound.BlockSoundGroup;
 import com.almuradev.almura.content.block.BuildableBlockType;
 import com.almuradev.almura.content.block.impl.GenericBlock;
 import com.almuradev.almura.content.material.AbstractMaterialTypeBuilder;
 import com.almuradev.almura.content.material.MapColor;
 import com.almuradev.almura.content.material.Material;
 import net.minecraft.block.Block;
+import net.minecraft.block.SoundType;
 import net.minecraft.block.state.IBlockState;
 import net.minecraft.client.renderer.block.model.ModelResourceLocation;
 import net.minecraft.creativetab.CreativeTabs;
@@ -24,6 +26,7 @@ import net.minecraft.item.ItemBlock;
 import net.minecraftforge.client.model.ModelLoader;
 import net.minecraftforge.fml.common.registry.GameRegistry;
 
+import java.util.Optional;
 import java.util.OptionalDouble;
 import java.util.OptionalInt;
 
@@ -41,6 +44,7 @@ public abstract class AbstractBlockTypeBuilder<BLOCK extends BuildableBlockType,
     private OptionalDouble lightEmission = OptionalDouble.empty();
     private OptionalInt lightOpacity = OptionalInt.empty();
     private OptionalDouble resistance = OptionalDouble.empty();
+    @Nullable private BlockSoundGroup soundGroup;
 
     @Override
     public final Material material() {
@@ -131,6 +135,17 @@ public abstract class AbstractBlockTypeBuilder<BLOCK extends BuildableBlockType,
     }
 
     @Override
+    public Optional<BlockSoundGroup> soundGroup() {
+        return Optional.ofNullable(this.soundGroup);
+    }
+
+    @Override
+    public BUILDER soundGroup(BlockSoundGroup group) {
+        this.soundGroup = group;
+        return (BUILDER) this;
+    }
+
+    @Override
     public BUILDER from(BuildableBlockType value) {
         super.from(value);
 
@@ -143,6 +158,7 @@ public abstract class AbstractBlockTypeBuilder<BLOCK extends BuildableBlockType,
         this.lightEmission(block.getLightValue(defaultState, null, null));
         this.lightOpacity(block.getLightOpacity(defaultState, null, null));
         this.resistance(block.blockResistance);
+        this.soundGroup((BlockSoundGroup) block.getSoundType());
 
         return (BUILDER) this;
     }
@@ -159,6 +175,7 @@ public abstract class AbstractBlockTypeBuilder<BLOCK extends BuildableBlockType,
         this.lightEmission = OptionalDouble.empty();
         this.lightOpacity = OptionalInt.empty();
         this.resistance = OptionalDouble.empty();
+        this.soundGroup = null;
 
         return (BUILDER) this;
     }
@@ -175,6 +192,7 @@ public abstract class AbstractBlockTypeBuilder<BLOCK extends BuildableBlockType,
         final Block block = GameRegistry.register(this.createBlock((BUILDER) this).setRegistryName(name));
         block.setUnlocalizedName(modid + "." + id.replace(Constants.Plugin.ID.concat(":"), "").replace("/", "."));
         block.setCreativeTab((CreativeTabs) this.itemGroup().orElse(null));
+        this.soundGroup().ifPresent(sound -> block.setSoundType((SoundType) sound));
         this.hardness().ifPresent(hardness -> block.setHardness((float) hardness));
         this.resistance().ifPresent(resistance -> block.setResistance((float) resistance));
         this.lightEmission().ifPresent(emission -> block.setLightLevel((float) emission));

--- a/src/main/java/com/almuradev/almura/content/block/sound/BlockSoundGroup.java
+++ b/src/main/java/com/almuradev/almura/content/block/sound/BlockSoundGroup.java
@@ -1,0 +1,44 @@
+/*
+ * This file is part of Almura, All Rights Reserved.
+ *
+ * Copyright (c) AlmuraDev <http://github.com/AlmuraDev/>
+ */
+package com.almuradev.almura.content.block.sound;
+
+import com.almuradev.almura.registry.BuildableCatalogType;
+import org.spongepowered.api.effect.sound.SoundType;
+
+// Extension of SpongeAPI BlockSoundGroup to make it a catalog type
+public interface BlockSoundGroup extends org.spongepowered.api.block.BlockSoundGroup, BuildableCatalogType {
+
+    interface Builder extends BuildableCatalogType.Builder<BlockSoundGroup, Builder> {
+
+        double volume();
+
+        Builder volume(double volume);
+
+        double pitch();
+
+        Builder pitch(double pitch);
+
+        SoundType breakSound();
+
+        Builder breakSound(SoundType sound);
+
+        SoundType stepSound();
+
+        Builder stepSound(SoundType sound);
+
+        SoundType placeSound();
+
+        Builder placeSound(SoundType sound);
+
+        SoundType hitSound();
+
+        Builder hitSound(SoundType sound);
+
+        SoundType fallSound();
+
+        Builder fallSound(SoundType sound);
+    }
+}

--- a/src/main/java/com/almuradev/almura/content/block/sound/BlockSoundGroupBuilder.java
+++ b/src/main/java/com/almuradev/almura/content/block/sound/BlockSoundGroupBuilder.java
@@ -1,0 +1,141 @@
+/*
+ * This file is part of Almura, All Rights Reserved.
+ *
+ * Copyright (c) AlmuraDev <http://github.com/AlmuraDev/>
+ */
+package com.almuradev.almura.content.block.sound;
+
+import static com.google.common.base.Preconditions.checkNotNull;
+import static com.google.common.base.Preconditions.checkState;
+
+import com.almuradev.almura.asm.mixin.interfaces.IMixinSetCatalogTypeId;
+import net.minecraft.util.SoundEvent;
+import org.spongepowered.api.effect.sound.SoundType;
+
+import javax.annotation.Nullable;
+
+public class BlockSoundGroupBuilder implements BlockSoundGroup.Builder {
+
+    @Nullable private Double volume;
+    @Nullable private Double pitch;
+    @Nullable private SoundType breakSound;
+    @Nullable private SoundType stepSound;
+    @Nullable private SoundType placeSound;
+    @Nullable private SoundType hitSound;
+    @Nullable private SoundType fallSound;
+
+    @Override
+    public double volume() {
+        return checkNotNull(this.volume);
+    }
+
+    @Override
+    public BlockSoundGroup.Builder volume(double volume) {
+        this.volume = volume;
+        return this;
+    }
+
+    @Override
+    public double pitch() {
+        return checkNotNull(this.pitch);
+    }
+
+    @Override
+    public BlockSoundGroup.Builder pitch(double pitch) {
+        this.pitch = pitch;
+        return this;
+    }
+
+    @Override
+    public SoundType breakSound() {
+        return this.breakSound;
+    }
+
+    @Override
+    public BlockSoundGroup.Builder breakSound(SoundType sound) {
+        this.breakSound = sound;
+        return this;
+    }
+
+    @Override
+    public SoundType stepSound() {
+        return this.stepSound;
+    }
+
+    @Override
+    public BlockSoundGroup.Builder stepSound(SoundType sound) {
+        this.stepSound = checkNotNull(sound, "fall sound");
+        return this;
+    }
+
+    @Override
+    public SoundType placeSound() {
+        return this.placeSound;
+    }
+
+    @Override
+    public BlockSoundGroup.Builder placeSound(SoundType sound) {
+        this.placeSound = checkNotNull(sound, "place sound");
+        return this;
+    }
+
+    @Override
+    public SoundType hitSound() {
+        return this.hitSound;
+    }
+
+    @Override
+    public BlockSoundGroup.Builder hitSound(SoundType sound) {
+        this.hitSound = checkNotNull(sound, "hit sound");
+        return this;
+    }
+
+    @Override
+    public SoundType fallSound() {
+        return this.fallSound;
+    }
+
+    @Override
+    public BlockSoundGroup.Builder fallSound(SoundType sound) {
+        this.fallSound = checkNotNull(sound, "fall sound");
+        return this;
+    }
+
+    @Override
+    public BlockSoundGroup.Builder from(BlockSoundGroup value) {
+        this.volume = value.getVolume();
+        this.pitch = value.getPitch();
+        this.breakSound = value.getBreakSound();
+        this.stepSound = value.getStepSound();
+        this.placeSound = value.getPlaceSound();
+        this.hitSound = value.getHitSound();
+        this.fallSound = value.getFallSound();
+        return this;
+    }
+
+    @Override
+    public BlockSoundGroup.Builder reset() {
+        this.volume = null;
+        this.pitch = null;
+        this.breakSound = null;
+        this.stepSound = null;
+        this.placeSound = null;
+        this.hitSound = null;
+        this.fallSound = null;
+        return this;
+    }
+
+    @Override
+    public BlockSoundGroup build(String id, String name) {
+        checkState(this.volume != null, "volume must be set");
+        checkState(this.pitch != null, "pitch must be set");
+        checkState(this.breakSound != null, "break sound must be set");
+        checkState(this.stepSound != null, "step sound must be set");
+        checkState(this.placeSound != null, "place sound must be set");
+        checkState(this.hitSound != null, "hit sound must be set");
+        checkState(this.fallSound != null, "fall sound must be set");
+        final BlockSoundGroup group = (BlockSoundGroup) new net.minecraft.block.SoundType(this.volume.floatValue(), this.pitch.floatValue(), (SoundEvent) this.breakSound, (SoundEvent) this.stepSound, (SoundEvent) this.placeSound, (SoundEvent) this.hitSound, (SoundEvent) this.fallSound);
+        ((IMixinSetCatalogTypeId) group).setId(id, name);
+        return group;
+    }
+}

--- a/src/main/java/com/almuradev/almura/content/block/sound/BlockSoundGroups.java
+++ b/src/main/java/com/almuradev/almura/content/block/sound/BlockSoundGroups.java
@@ -1,0 +1,43 @@
+/*
+ * This file is part of Almura, All Rights Reserved.
+ *
+ * Copyright (c) AlmuraDev <http://github.com/AlmuraDev/>
+ */
+package com.almuradev.almura.content.block.sound;
+
+import com.almuradev.almura.content.block.sound.BlockSoundGroup;
+import org.spongepowered.api.util.generator.dummy.DummyObjectProvider;
+
+public final class BlockSoundGroups {
+
+    // SORTFIELDS:ON
+
+    public static final BlockSoundGroup ANVIL = DummyObjectProvider.createFor(BlockSoundGroup.class, "anvil");
+
+    public static final BlockSoundGroup CLOTH = DummyObjectProvider.createFor(BlockSoundGroup.class, "cloth");
+
+    public static final BlockSoundGroup GLASS = DummyObjectProvider.createFor(BlockSoundGroup.class, "glass");
+
+    public static final BlockSoundGroup GROUND = DummyObjectProvider.createFor(BlockSoundGroup.class, "ground");
+
+    public static final BlockSoundGroup LADDER = DummyObjectProvider.createFor(BlockSoundGroup.class, "ladder");
+
+    public static final BlockSoundGroup METAL = DummyObjectProvider.createFor(BlockSoundGroup.class, "metal");
+
+    public static final BlockSoundGroup PLANT = DummyObjectProvider.createFor(BlockSoundGroup.class, "plant");
+
+    public static final BlockSoundGroup SAND = DummyObjectProvider.createFor(BlockSoundGroup.class, "sand");
+
+    public static final BlockSoundGroup SLIME = DummyObjectProvider.createFor(BlockSoundGroup.class, "slime");
+
+    public static final BlockSoundGroup SNOW = DummyObjectProvider.createFor(BlockSoundGroup.class, "snow");
+
+    public static final BlockSoundGroup STONE = DummyObjectProvider.createFor(BlockSoundGroup.class, "stone");
+
+    public static final BlockSoundGroup WOOD = DummyObjectProvider.createFor(BlockSoundGroup.class, "wood");
+
+    // SORTFIELDS:OFF
+
+    private BlockSoundGroups() {
+    }
+}

--- a/src/main/java/com/almuradev/almura/content/loader/AssetType.java
+++ b/src/main/java/com/almuradev/almura/content/loader/AssetType.java
@@ -7,8 +7,10 @@ package com.almuradev.almura.content.loader;
 
 import com.almuradev.almura.content.block.BuildableBlockType;
 import com.almuradev.almura.content.block.rotatable.HorizontalType;
+import com.almuradev.almura.content.block.sound.BlockSoundGroup;
 import com.almuradev.almura.content.item.BuildableItemType;
 import com.almuradev.almura.content.item.group.ItemGroup;
+import com.almuradev.almura.content.loader.stage.task.CreateBlockSoundGroupTask;
 import com.almuradev.almura.content.loader.stage.task.CreateItemGroupTask;
 import com.almuradev.almura.content.loader.stage.task.SetCommonBlockAttributesTask;
 import com.almuradev.almura.content.loader.stage.task.SetCommonMaterialAttributesTask;
@@ -21,7 +23,8 @@ public enum AssetType {
     ITEMGROUP(ItemGroup.Builder.class, CreateItemGroupTask.instance),
     BLOCK(BuildableBlockType.Builder.class, SetCommonMaterialAttributesTask.instance, SetCommonBlockAttributesTask.instance),
     HORIZONTAL(HorizontalType.Builder.class, SetCommonMaterialAttributesTask.instance, SetCommonBlockAttributesTask.instance),
-    ITEM(BuildableItemType.Builder.class, SetCommonMaterialAttributesTask.instance);
+    ITEM(BuildableItemType.Builder.class, SetCommonMaterialAttributesTask.instance),
+    SOUNDGROUP(BlockSoundGroup.Builder.class, CreateBlockSoundGroupTask.INSTANCE);
 
     private final String loggerName;
     private final Class<? extends BuildableCatalogType.Builder> builderClass;

--- a/src/main/java/com/almuradev/almura/content/loader/stage/LoadBlockSoundGroupsStage.java
+++ b/src/main/java/com/almuradev/almura/content/loader/stage/LoadBlockSoundGroupsStage.java
@@ -1,0 +1,28 @@
+/*
+ * This file is part of Almura, All Rights Reserved.
+ *
+ * Copyright (c) AlmuraDev <http://github.com/AlmuraDev/>
+ */
+package com.almuradev.almura.content.loader.stage;
+
+import com.almuradev.almura.content.loader.AssetType;
+import com.almuradev.almura.content.loader.stage.task.CreateBlockSoundGroupTask;
+import com.almuradev.almura.content.loader.stage.task.StageTask;
+
+public enum LoadBlockSoundGroupsStage implements LoaderStage {
+    INSTANCE;
+
+    @Override
+    public AssetType[] getValidAssetTypes() {
+        return new AssetType[] {
+                AssetType.SOUNDGROUP
+        };
+    }
+
+    @Override
+    public StageTask<?, ?>[] getStageTasks() {
+        return new StageTask<?, ?>[] {
+                CreateBlockSoundGroupTask.INSTANCE
+        };
+    }
+}

--- a/src/main/java/com/almuradev/almura/content/loader/stage/task/CreateBlockSoundGroupTask.java
+++ b/src/main/java/com/almuradev/almura/content/loader/stage/task/CreateBlockSoundGroupTask.java
@@ -1,0 +1,41 @@
+/*
+ * This file is part of Almura, All Rights Reserved.
+ *
+ * Copyright (c) AlmuraDev <http://github.com/AlmuraDev/>
+ */
+package com.almuradev.almura.content.loader.stage.task;
+
+import static com.google.common.base.Preconditions.checkNotNull;
+
+import com.almuradev.almura.Constants;
+import com.almuradev.almura.content.block.sound.BlockSoundGroup;
+import com.almuradev.almura.content.loader.AssetContext;
+import ninja.leaping.configurate.ConfigurationNode;
+import org.spongepowered.api.Sponge;
+import org.spongepowered.api.effect.sound.SoundType;
+
+public enum CreateBlockSoundGroupTask implements StageTask<BlockSoundGroup, BlockSoundGroup.Builder> {
+    INSTANCE;
+
+    @Override
+    public void execute(AssetContext<BlockSoundGroup, BlockSoundGroup.Builder> context) throws TaskExecutionFailedException {
+        final BlockSoundGroup.Builder builder = context.getBuilder();
+        final ConfigurationNode node = context.getAsset().getConfigurationNode();
+
+        final String id = context.getAsset().getName();
+        builder
+                .volume(node.getNode(Constants.Config.Block.SoundGroup.VOLUME).getDouble())
+                .pitch(node.getNode(Constants.Config.Block.SoundGroup.PITCH).getDouble())
+                .breakSound(this.getSound(node, Constants.Config.Block.SoundGroup.BREAK_SOUND))
+                .stepSound(this.getSound(node, Constants.Config.Block.SoundGroup.STEP_SOUND))
+                .placeSound(this.getSound(node, Constants.Config.Block.SoundGroup.PLACE_SOUND))
+                .hitSound(this.getSound(node, Constants.Config.Block.SoundGroup.HIT_SOUND))
+                .fallSound(this.getSound(node, Constants.Config.Block.SoundGroup.FALL_SOUND));
+        context.setCatalog(Sponge.getRegistry().register(BlockSoundGroup.class, builder.build(Constants.Plugin.ID + ':' + id, id)));
+    }
+
+    private SoundType getSound(final ConfigurationNode node, final String key) {
+        final String value = checkNotNull(node.getNode(key).getString(null), "missing %s", key).replace("_", ".");
+        return checkNotNull(Sponge.getRegistry().getType(SoundType.class, value).orElse(null), "missing sound '%s'", value);
+    }
+}

--- a/src/main/java/com/almuradev/almura/registry/BlockSoundGroupRegistryModule.java
+++ b/src/main/java/com/almuradev/almura/registry/BlockSoundGroupRegistryModule.java
@@ -1,0 +1,72 @@
+/*
+ * This file is part of Almura, All Rights Reserved.
+ *
+ * Copyright (c) AlmuraDev <http://github.com/AlmuraDev/>
+ */
+package com.almuradev.almura.registry;
+
+import com.almuradev.almura.asm.mixin.interfaces.IMixinSetCatalogTypeId;
+import com.almuradev.almura.content.block.sound.BlockSoundGroup;
+import com.almuradev.almura.content.block.sound.BlockSoundGroups;
+import org.spongepowered.api.registry.AdditionalCatalogRegistryModule;
+import org.spongepowered.api.registry.CatalogRegistryModule;
+import org.spongepowered.api.registry.RegistrationPhase;
+import org.spongepowered.api.registry.util.DelayedRegistration;
+import org.spongepowered.api.registry.util.RegisterCatalog;
+import org.spongepowered.common.SpongeImplHooks;
+
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Optional;
+
+public class BlockSoundGroupRegistryModule implements AdditionalCatalogRegistryModule<BlockSoundGroup> {
+
+    @RegisterCatalog(BlockSoundGroups.class)
+    public final Map<String, BlockSoundGroup> map = new HashMap<>(52);
+
+    @DelayedRegistration(RegistrationPhase.PRE_INIT)
+    @Override
+    public void registerDefaults() {
+        this.register("wood", net.minecraft.block.SoundType.WOOD);
+        this.register("ground", net.minecraft.block.SoundType.GROUND);
+        this.register("plant", net.minecraft.block.SoundType.PLANT);
+        this.register("stone", net.minecraft.block.SoundType.STONE);
+        this.register("metal", net.minecraft.block.SoundType.METAL);
+        this.register("glass", net.minecraft.block.SoundType.GLASS);
+        this.register("cloth", net.minecraft.block.SoundType.CLOTH);
+        this.register("sand", net.minecraft.block.SoundType.SAND);
+        this.register("snow", net.minecraft.block.SoundType.SNOW);
+        this.register("ladder", net.minecraft.block.SoundType.LADDER);
+        this.register("anvil", net.minecraft.block.SoundType.ANVIL);
+        this.register("slime", net.minecraft.block.SoundType.SLIME);
+    }
+
+    @Override
+    public void registerAdditionalCatalog(BlockSoundGroup group) {
+        this.map.put(group.getId(), group);
+    }
+
+    private void register(String id, final net.minecraft.block.SoundType group) {
+        final String name = id;
+        id = SpongeImplHooks.getModIdFromClass(group.getClass()) + ':' + id;
+        this.map.put(id, (BlockSoundGroup) group);
+        ((IMixinSetCatalogTypeId) group).setId(id, name);
+    }
+
+    @Override
+    public Optional<BlockSoundGroup> getById(String id) {
+        id = id.toLowerCase(Locale.ENGLISH);
+        if (!id.contains(":")) {
+            id = "minecraft:" + id;
+        }
+        return Optional.ofNullable(this.map.get(id));
+    }
+
+    @Override
+    public Collection<BlockSoundGroup> getAll() {
+        return Collections.unmodifiableCollection(this.map.values());
+    }
+}

--- a/src/main/java/com/almuradev/almura/registry/MapColorRegistryModule.java
+++ b/src/main/java/com/almuradev/almura/registry/MapColorRegistryModule.java
@@ -83,9 +83,11 @@ public class MapColorRegistryModule implements CatalogRegistryModule<MapColor> {
         this.register("light_blue_stained_hardened_clay", net.minecraft.block.material.MapColor.field_193560_ab);
     }
 
-    private void register(final String id, final net.minecraft.block.material.MapColor material) {
-        this.map.put(id, (MapColor) material);
-        ((IMixinSetCatalogTypeId) material).setId(SpongeImplHooks.getModIdFromClass(material.getClass()) + ':' + id, id);
+    private void register(String id, final net.minecraft.block.material.MapColor color) {
+        final String name = id;
+        id = SpongeImplHooks.getModIdFromClass(color.getClass()) + ':' + id;
+        this.map.put(id, (MapColor) color);
+        ((IMixinSetCatalogTypeId) color).setId(id, name);
     }
 
     @Override

--- a/src/main/java/com/almuradev/almura/registry/MaterialRegistryModule.java
+++ b/src/main/java/com/almuradev/almura/registry/MaterialRegistryModule.java
@@ -67,9 +67,11 @@ public class MaterialRegistryModule implements CatalogRegistryModule<Material> {
         this.register("structure_void", net.minecraft.block.material.Material.STRUCTURE_VOID);
     }
 
-    private void register(final String id, final net.minecraft.block.material.Material material) {
+    private void register(String id, final net.minecraft.block.material.Material material) {
+        final String name = id;
+        id = SpongeImplHooks.getModIdFromClass(material.getClass()) + ':' + id;
         this.map.put(id, (Material) material);
-        ((IMixinSetCatalogTypeId) material).setId(SpongeImplHooks.getModIdFromClass(material.getClass()) + ':' + id, id);
+        ((IMixinSetCatalogTypeId) material).setId(id, name);
     }
 
     @Override

--- a/src/main/resources/META-INF/almura_at.cfg
+++ b/src/main/resources/META-INF/almura_at.cfg
@@ -1,7 +1,9 @@
+public-f com.almuradev.almura.content.block.sound.BlockSoundGroups *
 public-f com.almuradev.almura.content.item.group.ItemGroups *
 public-f com.almuradev.almura.content.material.MapColors *
 public-f com.almuradev.almura.content.material.Materials *
 
 public net.minecraft.block.Block field_149781_w # blockResistance
 protected-f net.minecraft.block.Block field_181083_K # blockMapColor
+public net.minecraft.block.Block func_149672_a(Lnet/minecraft/block/SoundType;)Lnet/minecraft/block/Block; # setSoundType
 public net.minecraft.client.renderer.texture.TextureAtlasSprite <init>(Ljava/lang/String;)V

--- a/src/main/resources/mixins.almura.core.json
+++ b/src/main/resources/mixins.almura.core.json
@@ -10,6 +10,7 @@
         "block.MixinBlockCrops",
         "block.MixinBlockFarmland",
         "block.MixinBlockHorizontal",
+        "block.MixinSoundType",
         "block.material.MixinMapColor",
         "block.material.MixinMaterial",
         "creativetab.MixinCreativeTabs"


### PR DESCRIPTION
https://github.com/AlmuraDev/AssetConverter/pull/7
https://github.com/AlmuraDev/Almura-2.0-ContentPacks/pull/35

Example `.soundgroup`:
```json
{
    "volume": 0.1,
    "pitch": 0.1,
    "break-sound": "block.anvil.break",
    "step-sound": "block.anvil.step",
    "place-sound": "block.chest.open",
    "hit-sound": "block.dispenser.fail",
    "fall-sound": "block.glass.break"
}
```