### PR TITLE
Find out the actual cause of the crash

### DIFF
--- a/src/main/java/com/almuradev/almura/feature/hud/screen/origin/component/panel/debug/LookingDebugPanel.java
+++ b/src/main/java/com/almuradev/almura/feature/hud/screen/origin/component/panel/debug/LookingDebugPanel.java
@@ -116,10 +116,7 @@ public class LookingDebugPanel extends AbstractDebugPanel {
     }
 
     private void renderEntity(final Entity entity) {
-        if (entity == null) { //Catch entity being null during teleport event.
-            return;
-        }
-        final ResourceLocation id = requireNonNull(EntityList.getKey(entity));
+        final ResourceLocation id = requireNonNull(EntityList.getKey(entity), () -> "Entity of class " + entity.getClass() + " is not registered!");
 
         // Draw egg, if available
         if (EntityList.ENTITY_EGGS.containsKey(id)) {


### PR DESCRIPTION
The entity cannot be null, or the error is already thrown in `EntityList#getKey`. It is because of the unregistered entity class. Also, the entity in the ray trace have no possibility to be modified because the method `#drawForeground` is called in the super class' `#draw` method.

Original crash: https://gist.github.com/liach/598923ec4d8466b91f2c2645a5dbf6d6
Happened when dockter teleported me to the new castle.