### PR TITLE
Fixes the caches' upgrade recipe and added advanced inventory rendering for the cache blocks

### DIFF
--- a/src/main/java/com/almuradev/almura/feature/cache/CacheFeature.java
+++ b/src/main/java/com/almuradev/almura/feature/cache/CacheFeature.java
@@ -15,12 +15,9 @@ import com.almuradev.almura.feature.cache.client.tileentity.renderer.CacheTileEn
 import com.almuradev.almura.shared.tileentity.SingleSlotTileEntity;
 import com.almuradev.core.event.Witness;
 import net.minecraft.block.Block;
-import net.minecraft.client.Minecraft;
-import net.minecraft.client.renderer.block.model.IBakedModel;
 import net.minecraft.client.renderer.block.model.ModelResourceLocation;
 import net.minecraft.item.Item;
 import net.minecraft.item.ItemBlock;
-import net.minecraft.item.ItemStack;
 import net.minecraft.util.ResourceLocation;
 import net.minecraftforge.client.event.ModelRegistryEvent;
 import net.minecraftforge.client.model.ModelLoader;
@@ -31,9 +28,9 @@ import net.minecraftforge.fml.common.eventhandler.SubscribeEvent;
 import net.minecraftforge.fml.common.registry.GameRegistry;
 import net.minecraftforge.fml.relauncher.Side;
 import net.minecraftforge.fml.relauncher.SideOnly;
+import net.minecraftforge.registries.IForgeRegistry;
 import org.spongepowered.api.GameState;
 import org.spongepowered.api.event.Listener;
-import org.spongepowered.api.event.game.state.GameLoadCompleteEvent;
 import org.spongepowered.api.event.game.state.GamePreInitializationEvent;
 
 import java.text.NumberFormat;
@@ -61,19 +58,20 @@ public final class CacheFeature extends Witness.Impl implements Witness.Lifecycl
 
     @SubscribeEvent
     public void onRegisterItems(final RegistryEvent.Register<Item> event) {
-        registerItem(event, CacheBlocks.WOOD);
-        registerItem(event, CacheBlocks.IRON);
-        registerItem(event, CacheBlocks.GOLD);
-        registerItem(event, CacheBlocks.DIAMOND);
-        registerItem(event, CacheBlocks.NETHER);
-        registerItem(event, CacheBlocks.ENDER);
+        final IForgeRegistry<Item> registry = event.getRegistry();
+        registerItem(registry, CacheBlocks.WOOD);
+        registerItem(registry, CacheBlocks.IRON);
+        registerItem(registry, CacheBlocks.GOLD);
+        registerItem(registry, CacheBlocks.DIAMOND);
+        registerItem(registry, CacheBlocks.NETHER);
+        registerItem(registry, CacheBlocks.ENDER);
     }
 
-    private void registerItem(final RegistryEvent.Register<Item> event, final CacheBlock cacheBlock) {
+    private void registerItem(final IForgeRegistry<Item> registry, final CacheBlock cacheBlock) {
         final ResourceLocation registryName = requireNonNull(cacheBlock.getRegistryName());
         final ItemBlock item = (ItemBlock) new ItemBlock(cacheBlock).setRegistryName(registryName);
 
-        event.getRegistry().register(item);
+        registry.register(item);
     }
 
     @SubscribeEvent
@@ -104,20 +102,11 @@ public final class CacheFeature extends Witness.Impl implements Witness.Lifecycl
 
     @SideOnly(Side.CLIENT)
     private void bindBlockRenderer() {
-        ClientRegistry.bindTileEntitySpecialRenderer(SingleSlotTileEntity.class, new CacheTileEntityRenderer());
+        ClientRegistry.bindTileEntitySpecialRenderer(SingleSlotTileEntity.class, CacheTileEntityRenderer.INSTANCE);
     }
 
     @SideOnly(Side.CLIENT)
     private void registerInventoryModel(Item item, ResourceLocation blockName) {
         ModelLoader.setCustomModelResourceLocation(item, 0, new ModelResourceLocation(blockName, "inventory"));
-    }
-
-    @SideOnly(Side.CLIENT)
-    @Listener
-    public void loadComplete(GameLoadCompleteEvent event) {
-        IBakedModel model = Minecraft.getMinecraft().getRenderItem().getItemModelWithOverrides(new ItemStack(CacheBlocks.DIAMOND), null, null);
-        if (!model.isBuiltInRenderer()) {
-            throw new RuntimeException("NOT Builtin");
-        }
     }
 }

--- a/src/main/java/com/almuradev/almura/feature/cache/block/CacheBlock.java
+++ b/src/main/java/com/almuradev/almura/feature/cache/block/CacheBlock.java
@@ -272,7 +272,7 @@ public final class CacheBlock extends BlockContainer {
 
             isDirty = true;
         } else if (!cacheStack.isEmpty()) {
-            if (!handStack.isEmpty() && !ItemStack.areItemsEqual(handStack, cacheStack)) {
+            if (!handStack.isEmpty() && (!ItemStack.areItemsEqual(handStack, cacheStack) || !ItemStack.areItemStackTagsEqual(handStack, cacheStack))) {
                 ((Player) player).sendMessage(Text.of("This cache does not support this item! Try emptying the cache first."));
                 return true;
             }
@@ -392,7 +392,7 @@ public final class CacheBlock extends BlockContainer {
         return pickStack;
     }
 
-    private static ItemStack addCacheToStack(ItemStack targetStack, SingleSlotTileEntity cte) {
+    private static ItemStack addCacheToStack(final ItemStack targetStack, final SingleSlotTileEntity cte) {
         final ISingleSlotItemHandler itemHandler = (ISingleSlotItemHandler) cte.getCapability(CapabilityItemHandler.ITEM_HANDLER_CAPABILITY,
                 null);
 
@@ -450,5 +450,16 @@ public final class CacheBlock extends BlockContainer {
         final NBTTagCompound cacheCompound = tagCompound.getCompoundTag("Cache");
 
         SharedCapabilities.SINGLE_SLOT_ITEM_HANDLER_CAPABILITY.readNBT(itemHandler, null, cacheCompound.getCompoundTag(Almura.ID + ":single_slot"));
+    }
+
+    public static ItemStack getFromCache(final SingleSlotTileEntity cte) {
+        final ISingleSlotItemHandler itemHandler = (ISingleSlotItemHandler) cte.getCapability(CapabilityItemHandler.ITEM_HANDLER_CAPABILITY,
+                null);
+
+        if (itemHandler == null) {
+            return ItemStack.EMPTY;
+        }
+
+        return itemHandler.getStackInSlot(0);
     }
 }

--- a/src/main/java/com/almuradev/almura/feature/cache/block/CacheBlock.java
+++ b/src/main/java/com/almuradev/almura/feature/cache/block/CacheBlock.java
@@ -170,7 +170,7 @@ public final class CacheBlock extends BlockContainer {
 
         final TileEntity te = world.getTileEntity(pos);
 
-        if (te == null || !(te instanceof SingleSlotTileEntity)) {
+        if (!(te instanceof SingleSlotTileEntity)) {
             return;
         }
 
@@ -189,7 +189,7 @@ public final class CacheBlock extends BlockContainer {
             return;
         }
 
-        int amountToExtract = 0;
+        final int amountToExtract;
 
         if (player.isSneaking()) {
             amountToExtract =1;
@@ -235,7 +235,7 @@ public final class CacheBlock extends BlockContainer {
         }
 
         final TileEntity te = world.getTileEntity(pos);
-        if (te == null || !(te instanceof SingleSlotTileEntity)) {
+        if (!(te instanceof SingleSlotTileEntity)) {
             return false;
         }
 
@@ -345,7 +345,7 @@ public final class CacheBlock extends BlockContainer {
     {
         this.onBlockHarvested(world, pos, state, player);
 
-        cacheTe = world.getTileEntity(pos);
+        this.cacheTe = world.getTileEntity(pos);
 
         return world.setBlockState(pos, net.minecraft.init.Blocks.AIR.getDefaultState(), world.isRemote ? 11 : 3);
     }
@@ -363,18 +363,18 @@ public final class CacheBlock extends BlockContainer {
         TileEntity te = world.getTileEntity(pos);
 
         if (te == null) {
-            te = cacheTe;
+            te = this.cacheTe;
         }
 
-        if (te == null || !(te instanceof SingleSlotTileEntity)) {
+        if (!(te instanceof SingleSlotTileEntity)) {
             return;
         }
 
         final SingleSlotTileEntity cte = (SingleSlotTileEntity) te;
 
-        this.addCacheToStack(toDrop, cte);
+        addCacheToStack(toDrop, cte);
 
-        cacheTe = null;
+        this.cacheTe = null;
     }
 
     @Override
@@ -382,17 +382,17 @@ public final class CacheBlock extends BlockContainer {
         final ItemStack pickStack = new ItemStack(this, 1, 0);
 
         final TileEntity te = world.getTileEntity(pos);
-        if (te != null && te instanceof SingleSlotTileEntity) {
+        if (te instanceof SingleSlotTileEntity) {
             final SingleSlotTileEntity cte = (SingleSlotTileEntity) te;
 
             // Alright, we have a Cache...need to put it on a stack now
-            this.addCacheToStack(pickStack, cte);
+            addCacheToStack(pickStack, cte);
         }
 
         return pickStack;
     }
 
-    private ItemStack addCacheToStack(ItemStack targetStack, SingleSlotTileEntity cte) {
+    private static ItemStack addCacheToStack(ItemStack targetStack, SingleSlotTileEntity cte) {
         final ISingleSlotItemHandler itemHandler = (ISingleSlotItemHandler) cte.getCapability(CapabilityItemHandler.ITEM_HANDLER_CAPABILITY,
                 null);
 
@@ -420,34 +420,35 @@ public final class CacheBlock extends BlockContainer {
         super.onBlockPlacedBy(worldIn, pos, state, placer, stack);
 
         if (!worldIn.isRemote) {
-
-            final NBTTagCompound tagCompound = stack.getSubCompound("tag");
-
-            if (tagCompound == null) {
-                return;
-            }
-
-            if (!tagCompound.hasKey("Cache")) {
-                return;
-            }
-
-            final NBTTagCompound cacheCompound = tagCompound.getCompoundTag("Cache");
-
             final TileEntity te = worldIn.getTileEntity(pos);
 
-            if (te == null || !(te instanceof SingleSlotTileEntity)) {
+            if (!(te instanceof SingleSlotTileEntity)) {
                 return;
             }
 
             final SingleSlotTileEntity cte = (SingleSlotTileEntity) te;
-            final ISingleSlotItemHandler itemHandler = (ISingleSlotItemHandler) cte.getCapability(CapabilityItemHandler.ITEM_HANDLER_CAPABILITY,
-                    null);
 
-            if (itemHandler == null) {
-                return;
-            }
-
-            SharedCapabilities.SINGLE_SLOT_ITEM_HANDLER_CAPABILITY.readNBT(itemHandler, null, cacheCompound.getCompoundTag(Almura.ID + ":single_slot"));
+            addStackToCache(stack, cte);
         }
+    }
+
+    public static void addStackToCache(final ItemStack stack, final SingleSlotTileEntity cte) {
+        final ISingleSlotItemHandler itemHandler = (ISingleSlotItemHandler) cte.getCapability(CapabilityItemHandler.ITEM_HANDLER_CAPABILITY,
+                null);
+
+        if (itemHandler == null) {
+            return;
+        }
+
+        final NBTTagCompound tagCompound = stack.getSubCompound("tag");
+
+        if (tagCompound == null || !tagCompound.hasKey("Cache")) {
+            itemHandler.setStackInSlot(0, ItemStack.EMPTY);
+            return;
+        }
+
+        final NBTTagCompound cacheCompound = tagCompound.getCompoundTag("Cache");
+
+        SharedCapabilities.SINGLE_SLOT_ITEM_HANDLER_CAPABILITY.readNBT(itemHandler, null, cacheCompound.getCompoundTag(Almura.ID + ":single_slot"));
     }
 }

--- a/src/main/java/com/almuradev/almura/feature/cache/block/package-info.java
+++ b/src/main/java/com/almuradev/almura/feature/cache/block/package-info.java
@@ -1,0 +1,14 @@
+/*
+ * This file is part of Almura.
+ *
+ * Copyright (c) AlmuraDev <https://github.com/AlmuraDev/>
+ *
+ * All Rights Reserved.
+ */
+@ParametersAreNonnullByDefault
+@MethodsReturnNonnullByDefault
+package com.almuradev.almura.feature.cache.block;
+
+import mcp.MethodsReturnNonnullByDefault;
+
+import javax.annotation.ParametersAreNonnullByDefault;

--- a/src/main/java/com/almuradev/almura/feature/cache/client/tileentity/renderer/CacheItemRenderer.java
+++ b/src/main/java/com/almuradev/almura/feature/cache/client/tileentity/renderer/CacheItemRenderer.java
@@ -7,140 +7,42 @@
  */
 package com.almuradev.almura.feature.cache.client.tileentity.renderer;
 
-import com.almuradev.almura.feature.cache.CacheFeature;
 import com.almuradev.almura.feature.cache.block.CacheBlock;
 import com.almuradev.almura.shared.tileentity.SingleSlotTileEntity;
 import net.minecraft.block.BlockHorizontal;
+import net.minecraft.block.state.IBlockState;
 import net.minecraft.client.Minecraft;
-import net.minecraft.client.gui.FontRenderer;
-import net.minecraft.client.gui.Gui;
 import net.minecraft.client.renderer.GlStateManager;
-import net.minecraft.client.renderer.OpenGlHelper;
-import net.minecraft.client.renderer.block.model.ItemCameraTransforms;
 import net.minecraft.client.renderer.tileentity.TileEntityItemStackRenderer;
 import net.minecraft.item.ItemBlock;
 import net.minecraft.item.ItemStack;
 import net.minecraft.util.EnumFacing;
 import net.minecraftforge.fml.relauncher.Side;
 import net.minecraftforge.fml.relauncher.SideOnly;
-import net.minecraftforge.items.CapabilityItemHandler;
-import net.minecraftforge.items.IItemHandler;
-
-import static com.almuradev.almura.feature.cache.client.tileentity.renderer.CacheTileEntityRenderer.MAX_LINE_WIDTH;
-import static com.almuradev.almura.feature.cache.client.tileentity.renderer.CacheTileEntityRenderer.ZERO_QUANTITY;
 
 @SideOnly(Side.CLIENT)
 public final class CacheItemRenderer extends TileEntityItemStackRenderer {
 
     public static final CacheItemRenderer INSTANCE = new CacheItemRenderer();
     private final SingleSlotTileEntity tile = new SingleSlotTileEntity();
-    /*
-     * Prevents recursive drawing.
-     */
-    private boolean inUse = false;
 
     private CacheItemRenderer() {
     }
 
     @Override
-    public void renderByItem(ItemStack stack, float partialTicks) {
+    public void renderByItem(final ItemStack stack, final float partialTicks) {
         final CacheBlock block = (CacheBlock) ((ItemBlock) stack.getItem()).getBlock();
+        final IBlockState state = block.getDefaultState().withProperty(BlockHorizontal.FACING, EnumFacing.EAST);
 
         GlStateManager.translate(0D, 0D, 1.0D);
-        Minecraft.getMinecraft().getBlockRendererDispatcher().renderBlockBrightness(block.getDefaultState().withProperty(BlockHorizontal.FACING, EnumFacing.EAST), 1.0F);
+        Minecraft.getMinecraft().getBlockRendererDispatcher().renderBlockBrightness(state, 1.0F);
 
-        if (this.inUse) {
-            return;
-        }
+        final ItemStack previous = CacheBlock.getFromCache(this.tile);
         CacheBlock.addStackToCache(stack, this.tile);
-        final IItemHandler handler = this.tile.getCapability(CapabilityItemHandler.ITEM_HANDLER_CAPABILITY, null);
-        if (handler == null) {
-            return;
-        }
-        this.inUse = true;
-        render(handler.getStackInSlot(0), block, handler.getSlotLimit(0));
-        this.inUse = false;
-    }
 
-    private void render(final ItemStack cache, final CacheBlock block, int max) {
-        GlStateManager.pushMatrix();
+        CacheTileEntityRenderer.INSTANCE.render(this.tile, 0, 0, 0, state);
 
-        double translatedX = 0;
-        double translatedZ = 0;
 
-        final float angle = 90f;
-        translatedX += 1.025;
-        translatedZ += 0.5;
-
-        // Move the matrix to the front face, in the center
-        GlStateManager.translate(translatedX, 0.525f, translatedZ);
-        GlStateManager.rotate(angle, 0f, 1f, 0f);
-
-        // Set lightmap coordinates to the skylight value of the block in front of the cache item model
-        int light = 15 << 20 | 15 << 4;
-        int j = light % 65536;
-        int k = light / 65536;
-        OpenGlHelper.setLightmapTextureCoords(OpenGlHelper.lightmapTexUnit, j / 1.0F, k / 1.0F);
-        GlStateManager.color(1f, 1f, 1f, 1f);
-
-        // Rotate cache item model to fit default Vanilla cache icon look. We do not support rotating the item model
-        GlStateManager.rotate(180f, 0.0F, 1f, 0f);
-        GlStateManager.scale(0.5F, 0.5F, 0.5F);
-
-        // FIXED is meant for ItemFrame rendering which we are mimicing
-        Minecraft.getMinecraft().getRenderItem().renderItem(cache, ItemCameraTransforms.TransformType.FIXED);
-
-        // Revert lightmap texture coordinates to world values pre-render tick
-        OpenGlHelper.setLightmapTextureCoords(OpenGlHelper.lightmapTexUnit, OpenGlHelper.lastBrightnessX, OpenGlHelper.lastBrightnessY);
-
-        GlStateManager.popMatrix();
-
-        GlStateManager.pushMatrix();
-
-        // Translate to face the cache item model is on but at the bottom edge
-        GlStateManager.translate(translatedX, 0, translatedZ);
-        // Rotate on the y-axis by the angle
-        GlStateManager.rotate(angle, 0f, 1f, 0f);
-
-        // Scale the matrix by a scale factor (to make writing legible but not too big on block)
-        final float scaleFactor = 0.6666667F * 0.016666668F;
-        GlStateManager.scale(scaleFactor, -scaleFactor, scaleFactor);
-
-        final FontRenderer fontRenderer = Minecraft.getMinecraft().fontRenderer;
-
-        String displayName;
-        String cacheQuantity = ZERO_QUANTITY;
-
-        boolean empty = cache.isEmpty();
-
-        if (empty) {
-            displayName = block.getLocalizedName();
-        } else {
-            cacheQuantity = CacheFeature.format.format(cache.getCount());
-            displayName = cache.getDisplayName();
-        }
-
-        final String cacheMaxQuantity = CacheFeature.format.format(max);
-
-        // Check if we can fit the displayname on the first line, if not then split it to two lines at most
-        if (fontRenderer.getStringWidth(displayName) > MAX_LINE_WIDTH) {
-            int firstLineLength = displayName.length();
-            while (fontRenderer.getStringWidth(displayName.substring(0, firstLineLength)) > MAX_LINE_WIDTH) {
-                firstLineLength--;
-            }
-            final String firstLine = displayName.substring(0, firstLineLength);
-            final String secondLine = displayName.substring(firstLineLength);
-            fontRenderer.drawString(firstLine, -fontRenderer.getStringWidth(firstLine) / 2, -80, 0);
-            fontRenderer.drawString(secondLine, -fontRenderer.getStringWidth(secondLine) / 2, -70, 0);
-        } else {
-            fontRenderer.drawString(displayName, -fontRenderer.getStringWidth(displayName) / 2, -80, 0);
-        }
-
-        final int lineWidth = fontRenderer.getStringWidth(cacheMaxQuantity) / 2;
-        fontRenderer.drawString(cacheQuantity, -fontRenderer.getStringWidth(cacheQuantity) / 2, -24, 0);
-        Gui.drawRect(-lineWidth, -16, lineWidth, -15, 0xFF000000);
-        fontRenderer.drawString(cacheMaxQuantity, -fontRenderer.getStringWidth(cacheMaxQuantity) / 2, -14, 0);
-
-        GlStateManager.popMatrix();
+        CacheBlock.addStackToCache(previous, this.tile);
     }
 }

--- a/src/main/java/com/almuradev/almura/feature/cache/client/tileentity/renderer/CacheItemRenderer.java
+++ b/src/main/java/com/almuradev/almura/feature/cache/client/tileentity/renderer/CacheItemRenderer.java
@@ -1,0 +1,146 @@
+/*
+ * This file is part of Almura.
+ *
+ * Copyright (c) AlmuraDev <https://github.com/AlmuraDev/>
+ *
+ * All Rights Reserved.
+ */
+package com.almuradev.almura.feature.cache.client.tileentity.renderer;
+
+import com.almuradev.almura.feature.cache.CacheFeature;
+import com.almuradev.almura.feature.cache.block.CacheBlock;
+import com.almuradev.almura.shared.tileentity.SingleSlotTileEntity;
+import net.minecraft.block.BlockHorizontal;
+import net.minecraft.client.Minecraft;
+import net.minecraft.client.gui.FontRenderer;
+import net.minecraft.client.gui.Gui;
+import net.minecraft.client.renderer.GlStateManager;
+import net.minecraft.client.renderer.OpenGlHelper;
+import net.minecraft.client.renderer.block.model.ItemCameraTransforms;
+import net.minecraft.client.renderer.tileentity.TileEntityItemStackRenderer;
+import net.minecraft.item.ItemBlock;
+import net.minecraft.item.ItemStack;
+import net.minecraft.util.EnumFacing;
+import net.minecraftforge.fml.relauncher.Side;
+import net.minecraftforge.fml.relauncher.SideOnly;
+import net.minecraftforge.items.CapabilityItemHandler;
+import net.minecraftforge.items.IItemHandler;
+
+import static com.almuradev.almura.feature.cache.client.tileentity.renderer.CacheTileEntityRenderer.MAX_LINE_WIDTH;
+import static com.almuradev.almura.feature.cache.client.tileentity.renderer.CacheTileEntityRenderer.ZERO_QUANTITY;
+
+@SideOnly(Side.CLIENT)
+public final class CacheItemRenderer extends TileEntityItemStackRenderer {
+
+    public static final CacheItemRenderer INSTANCE = new CacheItemRenderer();
+    private final SingleSlotTileEntity tile = new SingleSlotTileEntity();
+    /*
+     * Prevents recursive drawing.
+     */
+    private boolean inUse = false;
+
+    private CacheItemRenderer() {
+    }
+
+    @Override
+    public void renderByItem(ItemStack stack, float partialTicks) {
+        final CacheBlock block = (CacheBlock) ((ItemBlock) stack.getItem()).getBlock();
+
+        GlStateManager.translate(0D, 0D, 1.0D);
+        Minecraft.getMinecraft().getBlockRendererDispatcher().renderBlockBrightness(block.getDefaultState().withProperty(BlockHorizontal.FACING, EnumFacing.EAST), 1.0F);
+
+        if (this.inUse) {
+            return;
+        }
+        CacheBlock.addStackToCache(stack, this.tile);
+        final IItemHandler handler = this.tile.getCapability(CapabilityItemHandler.ITEM_HANDLER_CAPABILITY, null);
+        if (handler == null) {
+            return;
+        }
+        this.inUse = true;
+        render(handler.getStackInSlot(0), block, handler.getSlotLimit(0));
+        this.inUse = false;
+    }
+
+    private void render(final ItemStack cache, final CacheBlock block, int max) {
+        GlStateManager.pushMatrix();
+
+        double translatedX = 0;
+        double translatedZ = 0;
+
+        final float angle = 90f;
+        translatedX += 1.025;
+        translatedZ += 0.5;
+
+        // Move the matrix to the front face, in the center
+        GlStateManager.translate(translatedX, 0.525f, translatedZ);
+        GlStateManager.rotate(angle, 0f, 1f, 0f);
+
+        // Set lightmap coordinates to the skylight value of the block in front of the cache item model
+        int light = 15 << 20 | 15 << 4;
+        int j = light % 65536;
+        int k = light / 65536;
+        OpenGlHelper.setLightmapTextureCoords(OpenGlHelper.lightmapTexUnit, j / 1.0F, k / 1.0F);
+        GlStateManager.color(1f, 1f, 1f, 1f);
+
+        // Rotate cache item model to fit default Vanilla cache icon look. We do not support rotating the item model
+        GlStateManager.rotate(180f, 0.0F, 1f, 0f);
+        GlStateManager.scale(0.5F, 0.5F, 0.5F);
+
+        // FIXED is meant for ItemFrame rendering which we are mimicing
+        Minecraft.getMinecraft().getRenderItem().renderItem(cache, ItemCameraTransforms.TransformType.FIXED);
+
+        // Revert lightmap texture coordinates to world values pre-render tick
+        OpenGlHelper.setLightmapTextureCoords(OpenGlHelper.lightmapTexUnit, OpenGlHelper.lastBrightnessX, OpenGlHelper.lastBrightnessY);
+
+        GlStateManager.popMatrix();
+
+        GlStateManager.pushMatrix();
+
+        // Translate to face the cache item model is on but at the bottom edge
+        GlStateManager.translate(translatedX, 0, translatedZ);
+        // Rotate on the y-axis by the angle
+        GlStateManager.rotate(angle, 0f, 1f, 0f);
+
+        // Scale the matrix by a scale factor (to make writing legible but not too big on block)
+        final float scaleFactor = 0.6666667F * 0.016666668F;
+        GlStateManager.scale(scaleFactor, -scaleFactor, scaleFactor);
+
+        final FontRenderer fontRenderer = Minecraft.getMinecraft().fontRenderer;
+
+        String displayName;
+        String cacheQuantity = ZERO_QUANTITY;
+
+        boolean empty = cache.isEmpty();
+
+        if (empty) {
+            displayName = block.getLocalizedName();
+        } else {
+            cacheQuantity = CacheFeature.format.format(cache.getCount());
+            displayName = cache.getDisplayName();
+        }
+
+        final String cacheMaxQuantity = CacheFeature.format.format(max);
+
+        // Check if we can fit the displayname on the first line, if not then split it to two lines at most
+        if (fontRenderer.getStringWidth(displayName) > MAX_LINE_WIDTH) {
+            int firstLineLength = displayName.length();
+            while (fontRenderer.getStringWidth(displayName.substring(0, firstLineLength)) > MAX_LINE_WIDTH) {
+                firstLineLength--;
+            }
+            final String firstLine = displayName.substring(0, firstLineLength);
+            final String secondLine = displayName.substring(firstLineLength);
+            fontRenderer.drawString(firstLine, -fontRenderer.getStringWidth(firstLine) / 2, -80, 0);
+            fontRenderer.drawString(secondLine, -fontRenderer.getStringWidth(secondLine) / 2, -70, 0);
+        } else {
+            fontRenderer.drawString(displayName, -fontRenderer.getStringWidth(displayName) / 2, -80, 0);
+        }
+
+        final int lineWidth = fontRenderer.getStringWidth(cacheMaxQuantity) / 2;
+        fontRenderer.drawString(cacheQuantity, -fontRenderer.getStringWidth(cacheQuantity) / 2, -24, 0);
+        Gui.drawRect(-lineWidth, -16, lineWidth, -15, 0xFF000000);
+        fontRenderer.drawString(cacheMaxQuantity, -fontRenderer.getStringWidth(cacheMaxQuantity) / 2, -14, 0);
+
+        GlStateManager.popMatrix();
+    }
+}

--- a/src/main/java/com/almuradev/almura/feature/cache/client/tileentity/renderer/CacheTileEntityRenderer.java
+++ b/src/main/java/com/almuradev/almura/feature/cache/client/tileentity/renderer/CacheTileEntityRenderer.java
@@ -28,14 +28,25 @@ import net.minecraftforge.items.CapabilityItemHandler;
 
 public final class CacheTileEntityRenderer extends TileEntitySpecialRenderer<SingleSlotTileEntity> {
 
+    public static final CacheTileEntityRenderer INSTANCE = new CacheTileEntityRenderer();
     static final int MAX_LINE_WIDTH = 84;
     static final String ZERO_QUANTITY = "0";
 
     private final Minecraft client = Minecraft.getMinecraft();
 
-    @Override
-    public void render(SingleSlotTileEntity te, double x, double y, double z, float partialTicks, int destroyStage, float alpha) {
+    private CacheTileEntityRenderer() {
+    }
 
+    @Override
+    public void render(final SingleSlotTileEntity te, final double x, final double y, final double z, final float partialTicks, final int destroyStage, final float alpha) {
+        final BlockPos pos = te.getPos();
+        final World world = te.getWorld();
+        final IBlockState blockState = world.getBlockState(pos);
+
+        render(te, x, y, z, blockState);
+    }
+
+    void render(final SingleSlotTileEntity te, final double x, final double y, final double z, final IBlockState blockState) {
         final ISingleSlotItemHandler
                 itemHandler = (ISingleSlotItemHandler) te.getCapability(CapabilityItemHandler.ITEM_HANDLER_CAPABILITY, null);
 
@@ -46,62 +57,55 @@ public final class CacheTileEntityRenderer extends TileEntitySpecialRenderer<Sin
         final ItemStack cache = itemHandler.getStackInSlot(0);
 
         final BlockPos pos = te.getPos();
-        final World world = te.getWorld();
-        final IBlockState blockState = world.getBlockState(pos);
 
         if (!(blockState.getBlock() instanceof CacheBlock)) {
             return;
         }
 
         final CacheBlock block = (CacheBlock) blockState.getBlock();
-        final int blockX = pos.getX();
-        final int blockY = pos.getY();
-        final int blockZ = pos.getZ();
 
         GlStateManager.pushMatrix();
 
         float angle = 0f;
         double translatedX = x;
         double translatedZ = z;
-        float brightness = 0f;
+        final EnumFacing facing = blockState.getValue(BlockHorizontal.FACING);
 
-        switch (blockState.getValue(BlockHorizontal.FACING)) {
+        switch (facing) {
             case SOUTH:
                 angle = 0f;
                 translatedX += 0.5;
                 translatedZ += 1.025;
-                brightness = blockState.getPackedLightmapCoords(world, new BlockPos(blockX, blockY, blockZ + 1));
                 break;
             case WEST:
                 angle = -90f;
                 translatedX -= 0.025;
                 translatedZ += 0.5;
-                brightness = blockState.getPackedLightmapCoords(world, new BlockPos(blockX - 1, blockY, blockZ));
                 break;
             case NORTH:
                 angle = 180f;
                 translatedX += 0.5;
                 translatedZ -= 0.025;
-                brightness = blockState.getPackedLightmapCoords(world, new BlockPos(blockX, blockY, blockZ - 1));
                 break;
             case EAST:
                 angle = 90f;
                 translatedX += 1.025;
                 translatedZ += 0.5;
-                brightness = blockState.getPackedLightmapCoords(world, new BlockPos(blockX + 1, blockY, blockZ));
                 break;
         }
+
+        final int brightness = te.hasWorld() ? blockState.getPackedLightmapCoords(te.getWorld(), pos.offset(facing)) : 15 << 20 | 15 << 4;
 
         // Move the matrix to the front face, in the center
         GlStateManager.translate(translatedX, y + 0.525f, translatedZ);
         GlStateManager.rotate(angle, 0f, 1f, 0f);
 
         // Set lightmap coordinates to the skylight value of the block in front of the cache item model
-        float j = brightness % 65536;
-        float k = brightness / 65536;
+        int j = brightness % 65536;
+        int k = brightness / 65536;
         OpenGlHelper.setLightmapTextureCoords(OpenGlHelper.lightmapTexUnit, j / 1.0F, k / 1.0F);
         GlStateManager.color(1f, 1f, 1f, 1f);
-        
+
         // Rotate cache item model to fit default Vanilla cache icon look. We do not support rotating the item model
         GlStateManager.rotate(180f, 0.0F, 1f, 0f);
         GlStateManager.scale(0.5F, 0.5F, 0.5F);

--- a/src/main/java/com/almuradev/almura/feature/cache/client/tileentity/renderer/CacheTileEntityRenderer.java
+++ b/src/main/java/com/almuradev/almura/feature/cache/client/tileentity/renderer/CacheTileEntityRenderer.java
@@ -21,17 +21,17 @@ import net.minecraft.client.renderer.OpenGlHelper;
 import net.minecraft.client.renderer.block.model.ItemCameraTransforms;
 import net.minecraft.client.renderer.tileentity.TileEntitySpecialRenderer;
 import net.minecraft.item.ItemStack;
+import net.minecraft.util.EnumFacing;
 import net.minecraft.util.math.BlockPos;
 import net.minecraft.world.World;
 import net.minecraftforge.items.CapabilityItemHandler;
 
 public final class CacheTileEntityRenderer extends TileEntitySpecialRenderer<SingleSlotTileEntity> {
 
-    private static final int MAX_LINE_WIDTH = 84;
-    private static final String ZERO_QUANTITY = "0";
+    static final int MAX_LINE_WIDTH = 84;
+    static final String ZERO_QUANTITY = "0";
 
     private final Minecraft client = Minecraft.getMinecraft();
-
 
     @Override
     public void render(SingleSlotTileEntity te, double x, double y, double z, float partialTicks, int destroyStage, float alpha) {
@@ -148,7 +148,7 @@ public final class CacheTileEntityRenderer extends TileEntitySpecialRenderer<Sin
                 firstLineLength--;
             }
             final String firstLine = displayName.substring(0, firstLineLength);
-            final String secondLine = displayName.substring(firstLineLength, displayName.length());
+            final String secondLine = displayName.substring(firstLineLength);
             fontRenderer.drawString(firstLine, -fontRenderer.getStringWidth(firstLine) / 2, (int) y -80, 0);
             fontRenderer.drawString(secondLine, -fontRenderer.getStringWidth(secondLine) / 2, (int) y - 70, 0);
         } else {

--- a/src/main/java/com/almuradev/almura/feature/cache/client/tileentity/renderer/package-info.java
+++ b/src/main/java/com/almuradev/almura/feature/cache/client/tileentity/renderer/package-info.java
@@ -1,0 +1,14 @@
+/*
+ * This file is part of Almura.
+ *
+ * Copyright (c) AlmuraDev <https://github.com/AlmuraDev/>
+ *
+ * All Rights Reserved.
+ */
+@ParametersAreNonnullByDefault
+@MethodsReturnNonnullByDefault
+package com.almuradev.almura.feature.cache.client.tileentity.renderer;
+
+import mcp.MethodsReturnNonnullByDefault;
+
+import javax.annotation.ParametersAreNonnullByDefault;

--- a/src/main/java/com/almuradev/almura/feature/cache/package-info.java
+++ b/src/main/java/com/almuradev/almura/feature/cache/package-info.java
@@ -1,0 +1,14 @@
+/*
+ * This file is part of Almura.
+ *
+ * Copyright (c) AlmuraDev <https://github.com/AlmuraDev/>
+ *
+ * All Rights Reserved.
+ */
+@ParametersAreNonnullByDefault
+@MethodsReturnNonnullByDefault
+package com.almuradev.almura.feature.cache;
+
+import mcp.MethodsReturnNonnullByDefault;
+
+import javax.annotation.ParametersAreNonnullByDefault;

--- a/src/main/java/com/almuradev/almura/feature/cache/recipe/CacheRecipe.java
+++ b/src/main/java/com/almuradev/almura/feature/cache/recipe/CacheRecipe.java
@@ -1,0 +1,88 @@
+/*
+ * This file is part of Almura.
+ *
+ * Copyright (c) AlmuraDev <https://github.com/AlmuraDev/>
+ *
+ * All Rights Reserved.
+ */
+package com.almuradev.almura.feature.cache.recipe;
+
+import com.almuradev.almura.Almura;
+import com.almuradev.almura.feature.cache.block.CacheBlock;
+import net.minecraft.inventory.InventoryCrafting;
+import net.minecraft.item.ItemBlock;
+import net.minecraft.item.ItemStack;
+import net.minecraft.item.crafting.Ingredient;
+import net.minecraft.item.crafting.ShapedRecipes;
+import net.minecraft.nbt.NBTTagCompound;
+import net.minecraft.util.NonNullList;
+
+public final class CacheRecipe extends ShapedRecipes {
+    public CacheRecipe(final String group, final int width, final int height, final NonNullList<Ingredient> ingredients, final ItemStack result) {
+        super(group, width, height, ingredients, result);
+    }
+
+    @Override
+    public ItemStack getCraftingResult(final InventoryCrafting inv) {
+        final ItemStack ret = super.getCraftingResult(inv);
+        modifyStack(inv, ret);
+        return ret;
+    }
+
+    private void modifyStack(final InventoryCrafting inventory, final ItemStack result) {
+        ItemStack cacheStack = ItemStack.EMPTY;
+
+        for (int i = 0; i < inventory.getSizeInventory(); i++) {
+            final ItemStack inSlot = inventory.getStackInSlot(i);
+            if (inSlot.getItem() instanceof ItemBlock && ((ItemBlock) inSlot.getItem()).getBlock() instanceof CacheBlock) {
+                cacheStack = inSlot;
+                break;
+            }
+        }
+
+        if (cacheStack.isEmpty()) {
+            return;
+        }
+
+        CacheBlock resultCacheBlock = (CacheBlock) ((ItemBlock) result.getItem()).getBlock();
+
+        final NBTTagCompound root = cacheStack.getTagCompound();
+
+        if (root == null || !root.hasKey("tag")) {
+            return;
+        }
+
+        final NBTTagCompound compound = root.getCompoundTag("tag");
+
+        if (!compound.hasKey("Cache")) {
+            return;
+        }
+
+        final NBTTagCompound cacheCompound = compound.getCompoundTag("Cache");
+
+        if (!cacheCompound.hasKey(Almura.ID + ":single_slot")) {
+            return;
+        }
+
+        final NBTTagCompound slotCompound = cacheCompound.getCompoundTag(Almura.ID + ":single_slot");
+
+        if (!slotCompound.hasKey("Slot")) {
+            return;
+        }
+
+        // Phew, we made it...
+
+        // Set the new slot limit
+        final int newSlotLimit = resultCacheBlock.getSlotLimit();
+        final NBTTagCompound newSlotCompound = slotCompound.copy();
+        newSlotCompound.setInteger("SlotLimit", newSlotLimit);
+
+        // Copy the old compound and set the new single slot compound
+        final NBTTagCompound newCompound = cacheStack.getTagCompound().copy();
+
+        // Really not clean but its late and I'll make it better later..
+        newCompound.getCompoundTag("tag").getCompoundTag("Cache").setTag(Almura.ID + ":single_slot", newSlotCompound);
+
+        result.setTagCompound(newCompound);
+    }
+}

--- a/src/main/java/com/almuradev/almura/feature/cache/recipe/CacheRecipeFactory.java
+++ b/src/main/java/com/almuradev/almura/feature/cache/recipe/CacheRecipeFactory.java
@@ -7,84 +7,34 @@
  */
 package com.almuradev.almura.feature.cache.recipe;
 
-import com.google.gson.JsonArray;
-import com.google.gson.JsonElement;
 import com.google.gson.JsonObject;
-import com.google.gson.JsonSyntaxException;
-import net.minecraft.item.ItemStack;
 import net.minecraft.item.crafting.IRecipe;
-import net.minecraft.item.crafting.Ingredient;
-import net.minecraft.util.JsonUtils;
-import net.minecraft.util.NonNullList;
+import net.minecraft.item.crafting.ShapedRecipes;
+import net.minecraft.util.ResourceLocation;
 import net.minecraftforge.common.crafting.CraftingHelper;
 import net.minecraftforge.common.crafting.IRecipeFactory;
 import net.minecraftforge.common.crafting.JsonContext;
+import net.minecraftforge.fml.relauncher.ReflectionHelper;
 
-import java.util.HashMap;
-import java.util.HashSet;
 import java.util.Map;
-import java.util.Set;
 
 @SuppressWarnings("unused")
 public final class CacheRecipeFactory implements IRecipeFactory {
+
+    private static final ResourceLocation SHAPED_CRAFTING_PARSER_NAME = new ResourceLocation("minecraft:crafting_shaped");
+    private final IRecipeFactory vanillaShapedCraftingFactory;
 
     /**
      * This constructor is called by forge via reflection.
      */
     public CacheRecipeFactory() {
+        Map<ResourceLocation, IRecipeFactory> map = ReflectionHelper.getPrivateValue(CraftingHelper.class, null, 4);
+        this.vanillaShapedCraftingFactory = map.get(SHAPED_CRAFTING_PARSER_NAME);
     }
 
     @Override
     public IRecipe parse(JsonContext context, JsonObject json) {
-        final String group = JsonUtils.getString(json, "group", "");
-
-        final Map<Character, Ingredient> ingMap = new HashMap<>();
-        for (final Map.Entry<String, JsonElement> entry: JsonUtils.getJsonObject(json, "key").entrySet()) {
-            if (entry.getKey().length() != 1)
-                throw new JsonSyntaxException("Invalid key entry: '" + entry.getKey() + "' is an invalid symbol (must be 1 character only).");
-            if (entry.getKey().charAt(0) == ' ')
-                throw new JsonSyntaxException("Invalid key entry: ' ' is a reserved symbol.");
-
-            ingMap.put(entry.getKey().toCharArray()[0], CraftingHelper.getIngredient(entry.getValue(), context));
-        }
-        ingMap.put(' ', Ingredient.EMPTY);
-
-        final JsonArray patternJ = JsonUtils.getJsonArray(json, "pattern");
-
-        if (patternJ.size() == 0)
-            throw new JsonSyntaxException("Invalid pattern: empty pattern not allowed");
-        if (patternJ.size() > 3)
-            throw new JsonSyntaxException("Invalid pattern: too many rows, 3 is maximum");
-
-        final String[] pattern = new String[patternJ.size()];
-        for (int x = 0; x < pattern.length; x++) {
-            final String line = JsonUtils.getString(patternJ.get(x), "pattern[" + x + "]");
-            if (line.length() > 3)
-                throw new JsonSyntaxException("Invalid pattern: too many columns, 3 is maximum");
-            if (x > 0 && pattern[0].length() != line.length())
-                throw new JsonSyntaxException("Invalid pattern: each row must be the same width");
-            pattern[x] = line;
-        }
-
-        final NonNullList<Ingredient> input = NonNullList.withSize(pattern[0].length() * pattern.length, Ingredient.EMPTY);
-        final Set<Character> keys = new HashSet<>(ingMap.keySet());
-        keys.remove(' ');
-
-        int x = 0;
-        for (final String line: pattern) {
-            for (final char chr: line.toCharArray()) {
-                final Ingredient ing = ingMap.get(chr);
-                if (ing == null)
-                    throw new JsonSyntaxException("Pattern references symbol '" + chr + "' but it's not defined in the key");
-                input.set(x++, ing);
-                keys.remove(chr);
-            }
-        }
-
-        if (!keys.isEmpty())
-            throw new JsonSyntaxException("Key defines symbols that aren't used in pattern: " + keys);
-
-        final ItemStack result = CraftingHelper.getItemStack(JsonUtils.getJsonObject(json, "result"), context);
-        return new CacheRecipe(group, pattern[0].length(), pattern.length, input, result);
+        final ShapedRecipes vanilla = (ShapedRecipes) this.vanillaShapedCraftingFactory.parse(context, json);
+        return new CacheRecipe(vanilla.group, vanilla.getWidth(), vanilla.getHeight(), vanilla.recipeItems, vanilla.getRecipeOutput());
     }
 }

--- a/src/main/java/com/almuradev/almura/feature/cache/recipe/CacheRecipeFactory.java
+++ b/src/main/java/com/almuradev/almura/feature/cache/recipe/CacheRecipeFactory.java
@@ -1,0 +1,90 @@
+/*
+ * This file is part of Almura.
+ *
+ * Copyright (c) AlmuraDev <https://github.com/AlmuraDev/>
+ *
+ * All Rights Reserved.
+ */
+package com.almuradev.almura.feature.cache.recipe;
+
+import com.google.gson.JsonArray;
+import com.google.gson.JsonElement;
+import com.google.gson.JsonObject;
+import com.google.gson.JsonSyntaxException;
+import net.minecraft.item.ItemStack;
+import net.minecraft.item.crafting.IRecipe;
+import net.minecraft.item.crafting.Ingredient;
+import net.minecraft.util.JsonUtils;
+import net.minecraft.util.NonNullList;
+import net.minecraftforge.common.crafting.CraftingHelper;
+import net.minecraftforge.common.crafting.IRecipeFactory;
+import net.minecraftforge.common.crafting.JsonContext;
+
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
+
+@SuppressWarnings("unused")
+public final class CacheRecipeFactory implements IRecipeFactory {
+
+    /**
+     * This constructor is called by forge via reflection.
+     */
+    public CacheRecipeFactory() {
+    }
+
+    @Override
+    public IRecipe parse(JsonContext context, JsonObject json) {
+        final String group = JsonUtils.getString(json, "group", "");
+
+        final Map<Character, Ingredient> ingMap = new HashMap<>();
+        for (final Map.Entry<String, JsonElement> entry: JsonUtils.getJsonObject(json, "key").entrySet()) {
+            if (entry.getKey().length() != 1)
+                throw new JsonSyntaxException("Invalid key entry: '" + entry.getKey() + "' is an invalid symbol (must be 1 character only).");
+            if (entry.getKey().charAt(0) == ' ')
+                throw new JsonSyntaxException("Invalid key entry: ' ' is a reserved symbol.");
+
+            ingMap.put(entry.getKey().toCharArray()[0], CraftingHelper.getIngredient(entry.getValue(), context));
+        }
+        ingMap.put(' ', Ingredient.EMPTY);
+
+        final JsonArray patternJ = JsonUtils.getJsonArray(json, "pattern");
+
+        if (patternJ.size() == 0)
+            throw new JsonSyntaxException("Invalid pattern: empty pattern not allowed");
+        if (patternJ.size() > 3)
+            throw new JsonSyntaxException("Invalid pattern: too many rows, 3 is maximum");
+
+        final String[] pattern = new String[patternJ.size()];
+        for (int x = 0; x < pattern.length; x++) {
+            final String line = JsonUtils.getString(patternJ.get(x), "pattern[" + x + "]");
+            if (line.length() > 3)
+                throw new JsonSyntaxException("Invalid pattern: too many columns, 3 is maximum");
+            if (x > 0 && pattern[0].length() != line.length())
+                throw new JsonSyntaxException("Invalid pattern: each row must be the same width");
+            pattern[x] = line;
+        }
+
+        final NonNullList<Ingredient> input = NonNullList.withSize(pattern[0].length() * pattern.length, Ingredient.EMPTY);
+        final Set<Character> keys = new HashSet<>(ingMap.keySet());
+        keys.remove(' ');
+
+        int x = 0;
+        for (final String line: pattern) {
+            for (final char chr: line.toCharArray()) {
+                final Ingredient ing = ingMap.get(chr);
+                if (ing == null)
+                    throw new JsonSyntaxException("Pattern references symbol '" + chr + "' but it's not defined in the key");
+                input.set(x++, ing);
+                keys.remove(chr);
+            }
+        }
+
+        if (!keys.isEmpty())
+            throw new JsonSyntaxException("Key defines symbols that aren't used in pattern: " + keys);
+
+        final ItemStack result = CraftingHelper.getItemStack(JsonUtils.getJsonObject(json, "result"), context);
+        return new CacheRecipe(group, pattern[0].length(), pattern.length, input, result);
+    }
+}

--- a/src/main/java/com/almuradev/almura/feature/cache/recipe/package-info.java
+++ b/src/main/java/com/almuradev/almura/feature/cache/recipe/package-info.java
@@ -1,0 +1,14 @@
+/*
+ * This file is part of Almura.
+ *
+ * Copyright (c) AlmuraDev <https://github.com/AlmuraDev/>
+ *
+ * All Rights Reserved.
+ */
+@ParametersAreNonnullByDefault
+@MethodsReturnNonnullByDefault
+package com.almuradev.almura.feature.cache.recipe;
+
+import mcp.MethodsReturnNonnullByDefault;
+
+import javax.annotation.ParametersAreNonnullByDefault;

--- a/src/main/resources/assets/almura/blockstates/cache/diamond.json
+++ b/src/main/resources/assets/almura/blockstates/cache/diamond.json
@@ -5,7 +5,11 @@
         "transform": "forge:default-block"
     },
     "variants": {
-        "inventory": [ { } ],
+        "inventory": [
+            {
+                "model": "almura:cache/item"
+            }
+        ],
         "facing": {
             "south": {
                 "y": 180.0

--- a/src/main/resources/assets/almura/blockstates/cache/ender.json
+++ b/src/main/resources/assets/almura/blockstates/cache/ender.json
@@ -5,7 +5,11 @@
         "transform": "forge:default-block"
     },
     "variants": {
-        "inventory": [ { } ],
+        "inventory": [
+            {
+                "model": "almura:cache/item"
+            }
+        ],
         "facing": {
             "south": {
                 "y": 180.0

--- a/src/main/resources/assets/almura/blockstates/cache/gold.json
+++ b/src/main/resources/assets/almura/blockstates/cache/gold.json
@@ -5,7 +5,11 @@
         "transform": "forge:default-block"
     },
     "variants": {
-        "inventory": [ { } ],
+        "inventory": [
+            {
+                "model": "almura:cache/item"
+            }
+        ],
         "facing": {
             "south": {
                 "y": 180.0

--- a/src/main/resources/assets/almura/blockstates/cache/iron.json
+++ b/src/main/resources/assets/almura/blockstates/cache/iron.json
@@ -5,7 +5,11 @@
         "transform": "forge:default-block"
     },
     "variants": {
-        "inventory": [ { } ],
+        "inventory": [
+            {
+                "model": "almura:cache/item"
+            }
+        ],
         "facing": {
             "south": {
                 "y": 180.0

--- a/src/main/resources/assets/almura/blockstates/cache/nether.json
+++ b/src/main/resources/assets/almura/blockstates/cache/nether.json
@@ -5,7 +5,11 @@
         "transform": "forge:default-block"
     },
     "variants": {
-        "inventory": [ { } ],
+        "inventory": [
+            {
+                "model": "almura:cache/item"
+            }
+        ],
         "facing": {
             "south": {
                 "y": 180.0

--- a/src/main/resources/assets/almura/blockstates/cache/wood.json
+++ b/src/main/resources/assets/almura/blockstates/cache/wood.json
@@ -5,7 +5,11 @@
         "transform": "forge:default-block"
     },
     "variants": {
-        "inventory": [ { } ],
+        "inventory": [
+            {
+                "model": "almura:cache/item"
+            }
+        ],
         "facing": {
             "south": {
                 "y": 180.0

--- a/src/main/resources/assets/almura/models/block/cache/item.json
+++ b/src/main/resources/assets/almura/models/block/cache/item.json
@@ -1,0 +1,35 @@
+{
+    "parent": "builtin/entity",
+    "display": {
+        "gui": {
+            "rotation": [ 30, 225, 0 ],
+            "translation": [ 0, 0, 0 ],
+            "scale": [ 0.625, 0.625, 0.625 ]
+        },
+        "ground": {
+            "rotation": [ 0, 0, 0 ],
+            "translation": [ 0, 3, 0 ],
+            "scale": [ 0.25, 0.25, 0.25 ]
+        },
+        "head": {
+            "rotation": [ 0, 0, 0 ],
+            "translation": [ 0, 0, 0 ],
+            "scale": [ 1, 1, 1 ]
+        },
+        "fixed": {
+            "rotation": [ 0, 0, 0 ],
+            "translation": [ 0, 0, 0 ],
+            "scale": [ 0.5, 0.5, 0.5 ]
+        },
+        "thirdperson_righthand": {
+            "rotation": [ 75, 135, 0 ],
+            "translation": [ 0, 2.5, 0 ],
+            "scale": [ 0.375, 0.375, 0.375 ]
+        },
+        "firstperson_righthand": {
+            "rotation": [ 0, 135, 0 ],
+            "translation": [ 0, 0, 0 ],
+            "scale": [ 0.4, 0.4, 0.4 ]
+        }
+    }
+}

--- a/src/main/resources/assets/almura/recipes/_factories.json
+++ b/src/main/resources/assets/almura/recipes/_factories.json
@@ -1,0 +1,5 @@
+{
+    "recipes": {
+        "cache_shaped": "com.almuradev.almura.feature.cache.recipe.CacheRecipeFactory"
+    }
+}

--- a/src/main/resources/assets/almura/recipes/diamond_cache.json
+++ b/src/main/resources/assets/almura/recipes/diamond_cache.json
@@ -1,5 +1,5 @@
 {
-    "type": "minecraft:crafting_shaped",
+    "type": "almura:cache_shaped",
     "pattern": [
         "AAA",
         "ABA",

--- a/src/main/resources/assets/almura/recipes/ender_cache.json
+++ b/src/main/resources/assets/almura/recipes/ender_cache.json
@@ -1,5 +1,5 @@
 {
-    "type": "minecraft:crafting_shaped",
+    "type": "almura:cache_shaped",
     "pattern": [
         "AAA",
         "ABA",

--- a/src/main/resources/assets/almura/recipes/gold_cache.json
+++ b/src/main/resources/assets/almura/recipes/gold_cache.json
@@ -1,5 +1,5 @@
 {
-    "type": "minecraft:crafting_shaped",
+    "type": "almura:cache_shaped",
     "pattern": [
         "AAA",
         "ABA",

--- a/src/main/resources/assets/almura/recipes/iron_cache.json
+++ b/src/main/resources/assets/almura/recipes/iron_cache.json
@@ -1,5 +1,5 @@
 {
-    "type": "minecraft:crafting_shaped",
+    "type": "almura:cache_shaped",
     "pattern": [
         "AAA",
         "ABA",

--- a/src/main/resources/assets/almura/recipes/nether_cache.json
+++ b/src/main/resources/assets/almura/recipes/nether_cache.json
@@ -1,5 +1,5 @@
 {
-    "type": "minecraft:crafting_shaped",
+    "type": "almura:cache_shaped",
     "pattern": [
         "AAA",
         "ABA",


### PR DESCRIPTION
The upgrade recipe is now done with vanilla recipes instead of event listeners.

Sample of new rendering:
![2018-07-05_01 22 00](https://user-images.githubusercontent.com/7806504/42311840-9e5f9e60-7ff3-11e8-8671-43c5fd2963cb.png)

Signed-off-by: liach <liach@users.noreply.github.com>