### PR TITLE
Regards tool class and tool level for block destory actions

### DIFF
--- a/src/main/java/com/almuradev/content/type/action/type/blockdestroy/BlockDestroyAction.java
+++ b/src/main/java/com/almuradev/content/type/action/type/blockdestroy/BlockDestroyAction.java
@@ -10,7 +10,7 @@ package com.almuradev.content.type.action.type.blockdestroy;
 import com.almuradev.content.component.apply.Apply;
 import com.almuradev.content.type.action.ActionContentType;
 import com.almuradev.content.type.action.component.drop.Drop;
-import com.almuradev.content.type.item.definition.ItemDefinition;
+import com.almuradev.content.type.item.definition.ItemAcceptable;
 import net.minecraft.item.ItemStack;
 import org.spongepowered.api.item.ItemType;
 
@@ -26,6 +26,7 @@ public interface BlockDestroyAction extends ActionContentType {
     interface Entry {
         boolean test(final ItemStack stack);
 
+        @Deprecated
         boolean test(final ItemType type);
 
         List<? extends Apply> apply();
@@ -37,7 +38,7 @@ public interface BlockDestroyAction extends ActionContentType {
 
             void drop(final List<? extends Drop> drop);
 
-            void with(final List<ItemDefinition> with);
+            void with(final List<ItemAcceptable> with);
 
             Entry build();
         }

--- a/src/main/java/com/almuradev/content/type/action/type/blockdestroy/BlockDestroyActionConfig.java
+++ b/src/main/java/com/almuradev/content/type/action/type/blockdestroy/BlockDestroyActionConfig.java
@@ -11,4 +11,5 @@ public interface BlockDestroyActionConfig {
     String APPLY = "apply";
     String DROP = "drop";
     String WITH = "with";
+    String TOOL = "tool";
 }

--- a/src/main/java/com/almuradev/content/type/action/type/blockdestroy/BlockDestroyActionEntry.java
+++ b/src/main/java/com/almuradev/content/type/action/type/blockdestroy/BlockDestroyActionEntry.java
@@ -9,7 +9,7 @@ package com.almuradev.content.type.action.type.blockdestroy;
 
 import com.almuradev.content.component.apply.Apply;
 import com.almuradev.content.type.action.component.drop.Drop;
-import com.almuradev.content.type.item.definition.ItemDefinition;
+import com.almuradev.content.type.item.definition.ItemAcceptable;
 import net.minecraft.item.ItemStack;
 import org.spongepowered.api.item.ItemType;
 
@@ -18,7 +18,7 @@ import java.util.List;
 public final class BlockDestroyActionEntry implements BlockDestroyAction.Entry {
     private final List<Apply> apply;
     private final List<? extends Drop> drop;
-    private final List<ItemDefinition> with;
+    private final List<ItemAcceptable> with;
     private final boolean emptyWith;
 
     private BlockDestroyActionEntry(final Builder builder) {
@@ -34,6 +34,7 @@ public final class BlockDestroyActionEntry implements BlockDestroyAction.Entry {
     }
 
     @Override
+    @Deprecated
     public boolean test(final ItemType type) {
         final boolean match = this.with.stream().anyMatch(item -> item.test(type));
 
@@ -61,7 +62,7 @@ public final class BlockDestroyActionEntry implements BlockDestroyAction.Entry {
     public static class Builder implements BlockDestroyAction.Entry.Builder {
         private List<Apply> apply;
         private List<? extends Drop> drop;
-        private List<ItemDefinition> with;
+        private List<ItemAcceptable> with;
 
         @Override
         public void apply(final List<Apply> apply) {
@@ -74,7 +75,7 @@ public final class BlockDestroyActionEntry implements BlockDestroyAction.Entry {
         }
 
         @Override
-        public void with(final List<ItemDefinition> with) {
+        public void with(final List<ItemAcceptable> with) {
             this.with = with;
         }
 

--- a/src/main/java/com/almuradev/content/type/action/type/blockdestroy/processor/BlockDestroyActionContentProcessor.java
+++ b/src/main/java/com/almuradev/content/type/action/type/blockdestroy/processor/BlockDestroyActionContentProcessor.java
@@ -12,17 +12,19 @@ import com.almuradev.content.type.action.ActionContentProcessor;
 import com.almuradev.content.type.action.component.drop.DropParser;
 import com.almuradev.content.type.action.type.blockdestroy.BlockDestroyAction;
 import com.almuradev.content.type.action.type.blockdestroy.BlockDestroyActionConfig;
+import com.almuradev.content.type.item.definition.ItemAcceptable;
 import com.almuradev.content.type.item.definition.ItemDefinition;
+import com.almuradev.content.type.item.definition.ToolDefinition;
 import com.almuradev.toolbox.config.processor.AbstractArrayConfigProcessor;
 import com.almuradev.toolbox.config.processor.ArrayConfigProcessor;
 import ninja.leaping.configurate.ConfigurationNode;
 
+import javax.inject.Inject;
+import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
 import java.util.stream.Collectors;
-
-import javax.inject.Inject;
 
 public final class BlockDestroyActionContentProcessor implements ArrayConfigProcessor<BlockDestroyAction.Builder>, AbstractArrayConfigProcessor.EqualTreatment<BlockDestroyAction.Builder>, ActionContentProcessor<BlockDestroyAction, BlockDestroyAction.Builder> {
     private final ApplyParser action;
@@ -39,7 +41,9 @@ public final class BlockDestroyActionContentProcessor implements ArrayConfigProc
         final BlockDestroyAction.Entry.Builder entry = builder.entry(index);
         entry.apply(this.action.parse(config.getNode(BlockDestroyActionConfig.APPLY)));
         entry.drop(this.drop.parse(config.getNode(BlockDestroyActionConfig.DROP)));
-        entry.with(this.with(config.getNode(BlockDestroyActionConfig.WITH)));
+        final List<ItemAcceptable> with = new ArrayList<>(this.with(config.getNode(BlockDestroyActionConfig.WITH)));
+        with.addAll(tool(config.getNode(BlockDestroyActionConfig.TOOL)));
+        entry.with(with);
     }
 
     private List<ItemDefinition> with(final ConfigurationNode config) {
@@ -51,6 +55,20 @@ public final class BlockDestroyActionContentProcessor implements ArrayConfigProc
         }
         return config.getChildrenList().stream()
                 .map(ItemDefinition.PARSER::deserialize)
+                .filter(Optional::isPresent)
+                .map(Optional::get)
+                .collect(Collectors.toList());
+    }
+
+    private List<ToolDefinition> tool(final ConfigurationNode config) {
+        final Object value = config.getValue();
+        if (value instanceof String || value instanceof ConfigurationNode) {
+            return ToolDefinition.PARSER.deserialize(config)
+                    .map(Collections::singletonList)
+                    .orElse(Collections.emptyList());
+        }
+        return config.getChildrenList().stream()
+                .map(ToolDefinition.PARSER::deserialize)
                 .filter(Optional::isPresent)
                 .map(Optional::get)
                 .collect(Collectors.toList());

--- a/src/main/java/com/almuradev/content/type/action/type/blockdestroy/processor/BlockDestroyActionContentProcessor.java
+++ b/src/main/java/com/almuradev/content/type/action/type/blockdestroy/processor/BlockDestroyActionContentProcessor.java
@@ -42,7 +42,7 @@ public final class BlockDestroyActionContentProcessor implements ArrayConfigProc
         entry.apply(this.action.parse(config.getNode(BlockDestroyActionConfig.APPLY)));
         entry.drop(this.drop.parse(config.getNode(BlockDestroyActionConfig.DROP)));
         final List<ItemAcceptable> with = new ArrayList<>(this.with(config.getNode(BlockDestroyActionConfig.WITH)));
-        with.addAll(tool(config.getNode(BlockDestroyActionConfig.TOOL)));
+        with.addAll(this.tool(config.getNode(BlockDestroyActionConfig.TOOL)));
         entry.with(with);
     }
 

--- a/src/main/java/com/almuradev/content/type/block/facet/BlockExperience.java
+++ b/src/main/java/com/almuradev/content/type/block/facet/BlockExperience.java
@@ -18,8 +18,8 @@ import net.minecraft.world.World;
 import net.minecraftforge.event.world.BlockEvent;
 import net.minecraftforge.fml.common.eventhandler.EventPriority;
 import net.minecraftforge.fml.common.eventhandler.SubscribeEvent;
-import org.spongepowered.api.item.ItemType;
 import org.spongepowered.api.item.inventory.ItemStack;
+import org.spongepowered.common.item.inventory.util.ItemStackUtil;
 
 import java.util.Random;
 
@@ -51,11 +51,11 @@ public final class BlockExperience implements Witness {
             return;
         }
 
-        int experience = this.calculate((ItemType) event.getPlayer().getActiveItemStack().getItem(), destroyAction, world.rand);
+        int experience = this.calculate(event.getPlayer().getActiveItemStack(), destroyAction, world.rand);
 
         if (experience == NO_EXPERIENCE) {
             // if no exp for this itemstack, fallback to empty hand and check again
-            experience = this.calculate(ItemStack.empty().getType(), destroyAction, world.rand);
+            experience = this.calculate(ItemStackUtil.toNative(ItemStack.empty()), destroyAction, world.rand);
         }
 
         if (experience != NO_EXPERIENCE) {
@@ -63,7 +63,7 @@ public final class BlockExperience implements Witness {
         }
     }
 
-    private int calculate(final ItemType with, final BlockDestroyAction destroyAction, final Random random) {
+    private int calculate(final net.minecraft.item.ItemStack with, final BlockDestroyAction destroyAction, final Random random) {
         int experience = NO_EXPERIENCE;
         for (final BlockDestroyAction.Entry entry : destroyAction.entries()) {
             if (entry.test(with)) {

--- a/src/main/java/com/almuradev/content/type/block/util/BlockUtil.java
+++ b/src/main/java/com/almuradev/content/type/block/util/BlockUtil.java
@@ -31,7 +31,6 @@ import net.minecraft.tileentity.TileEntity;
 import net.minecraft.util.math.BlockPos;
 import net.minecraft.world.World;
 import net.minecraft.world.biome.Biome;
-import org.spongepowered.api.item.ItemType;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -54,7 +53,7 @@ public class BlockUtil {
             return;
         }
 
-        final Block mcBlock = (Block) (Object) block;
+        final Block mcBlock = (Block) block;
 
         player.addStat(StatList.getBlockStats(mcBlock));
 
@@ -77,17 +76,17 @@ public class BlockUtil {
             block.getHarvesters().set(player);
 
             // Almura Start - Run through the kitkats and break!
-            if (!fireBreakActions((ItemType) stack.getItem(), state, player, pos, world.rand, stack, blockDestroyAction)) {
+            if (!fireBreakActions(stack, state, player, pos, world.rand, stack, blockDestroyAction)) {
                 // Fallback to empty action block if nothing overrides it
-                fireBreakActions(org.spongepowered.api.item.inventory.ItemStack.empty().getType(), state, player, pos, world.rand, stack,
+                fireBreakActions(ItemStack.EMPTY, state, player, pos, world.rand, stack,
                         blockDestroyAction);
             }
 
             // TODO Expose fortune to config and see if admin wants to let it use it
             final int fortune = EnchantmentHelper.getEnchantmentLevel(Enchantments.FORTUNE, stack);
-            if (!fireHarvestAndDrop(block, (ItemType) stack.getItem(), world, pos, state, 1f, fortune, blockDestroyAction)) {
+            if (!fireHarvestAndDrop(block, stack, world, pos, state, 1f, fortune, blockDestroyAction)) {
                 // Fallback to empty drop block if nothing overrides it
-                fireHarvestAndDrop(block, org.spongepowered.api.item.inventory.ItemStack.empty().getType(), world, pos, state, 1f, fortune,
+                fireHarvestAndDrop(block, ItemStack.EMPTY, world, pos, state, 1f, fortune,
                         blockDestroyAction);
             }
 
@@ -126,7 +125,7 @@ public class BlockUtil {
                     return;
                 }
 
-                fireHarvestAndDrop(block, org.spongepowered.api.item.inventory.ItemStack.empty().getType(), world, pos, state, chance, fortune,
+                fireHarvestAndDrop(block, ItemStack.EMPTY, world, pos, state, chance, fortune,
                         blockDestroyAction);
             } else {
                 final IMixinDecayBlock decayBlock = (IMixinDecayBlock) block;
@@ -164,7 +163,7 @@ public class BlockUtil {
         }
     }
 
-    private static boolean fireBreakActions(final ItemType usedType, final IBlockState state, final EntityPlayer player, final BlockPos pos, final
+    private static boolean fireBreakActions(final ItemStack test, final IBlockState state, final EntityPlayer player, final BlockPos pos, final
     Random random, final ItemStack stack, @Nullable final BlockDestroyAction destroyAction) {
         if (destroyAction == null) {
             return true;
@@ -174,7 +173,7 @@ public class BlockUtil {
 
         final ApplyContext context = new EverythingApplyContext(random, pos, state, stack);
         for (final BlockDestroyAction.Entry entry : destroyAction.entries()) {
-            if (entry.test(usedType)) {
+            if (entry.test(test)) {
                 for (final Apply action : entry.apply()) {
                     if (action.accepts(player)) {
                         hasActions = true;
@@ -187,7 +186,7 @@ public class BlockUtil {
         return hasActions;
     }
 
-    private static boolean fireHarvestAndDrop(final IMixinContentBlock block, final ItemType type, final World world, final BlockPos pos,
+    private static boolean fireHarvestAndDrop(final IMixinContentBlock block, final ItemStack stack, final World world, final BlockPos pos,
             final IBlockState state, float chance, final int fortune, @Nullable final BlockDestroyAction destroyAction) {
 
         if (destroyAction == null) {
@@ -197,7 +196,7 @@ public class BlockUtil {
         final List<ItemStack> drops = new ArrayList<>();
 
         for (final BlockDestroyAction.Entry entry : destroyAction.entries()) {
-            if (entry.test(type)) {
+            if (entry.test(stack)) {
                 for (final Drop drop : entry.drops()) {
                     if (drop instanceof ItemDrop) {
                         ((ItemDrop) drop).fill(drops, world.rand);

--- a/src/main/java/com/almuradev/content/type/item/definition/ItemAcceptable.java
+++ b/src/main/java/com/almuradev/content/type/item/definition/ItemAcceptable.java
@@ -16,10 +16,10 @@ import java.util.function.Predicate;
 public interface ItemAcceptable extends Predicate<ItemStack> {
 
     @Override
-    boolean test(ItemStack stack);
+    boolean test(final ItemStack stack);
 
     @Deprecated
-    default boolean test(ItemType item) {
-        return test(new ItemStack((Item) item));
+    default boolean test(final ItemType item) {
+        return this.test(new ItemStack((Item) item));
     }
 }

--- a/src/main/java/com/almuradev/content/type/item/definition/ItemAcceptable.java
+++ b/src/main/java/com/almuradev/content/type/item/definition/ItemAcceptable.java
@@ -1,0 +1,25 @@
+/*
+ * This file is part of Almura.
+ *
+ * Copyright (c) AlmuraDev <https://github.com/AlmuraDev/>
+ *
+ * All Rights Reserved.
+ */
+package com.almuradev.content.type.item.definition;
+
+import net.minecraft.item.Item;
+import net.minecraft.item.ItemStack;
+import org.spongepowered.api.item.ItemType;
+
+import java.util.function.Predicate;
+
+public interface ItemAcceptable extends Predicate<ItemStack> {
+
+    @Override
+    boolean test(ItemStack stack);
+
+    @Deprecated
+    default boolean test(ItemType item) {
+        return test(new ItemStack((Item) item));
+    }
+}

--- a/src/main/java/com/almuradev/content/type/item/definition/ItemDefinition.java
+++ b/src/main/java/com/almuradev/content/type/item/definition/ItemDefinition.java
@@ -26,7 +26,7 @@ import java.util.Optional;
 
 import javax.annotation.Nullable;
 
-public final class ItemDefinition implements Droppable {
+public final class ItemDefinition implements Droppable, ItemAcceptable {
     @Deprecated private static final int DEFAULT_META = 0;
     private static final int DEFAULT_QUANTITY = 1;
     public static final ConfigurationNodeDeserializer<ItemDefinition> PARSER = config -> {
@@ -78,10 +78,13 @@ public final class ItemDefinition implements Droppable {
         this.meta = meta;
     }
 
+    @Override
     public boolean test(final ItemStack stack) {
         return this.item.get().equals(stack.getItem()) && this.meta == stack.getItemDamage();
     }
 
+    @Deprecated
+    @Override
     public boolean test(final ItemType type) {
         return this.item.get().getType().equals(type);
     }

--- a/src/main/java/com/almuradev/content/type/item/definition/ToolDefinition.java
+++ b/src/main/java/com/almuradev/content/type/item/definition/ToolDefinition.java
@@ -21,31 +21,31 @@ public final class ToolDefinition implements ItemAcceptable {
             return Optional.empty();
         }
 
-        // tool_class:
+        // tool_type:
         //   level: <value>
         if (node.getValue() instanceof Map) {
             final Map.Entry<Object, ? extends ConfigurationNode> entry = node.getChildrenMap().entrySet().iterator().next();
-            final String toolClass = String.valueOf(entry.getKey());
+            final String toolType = String.valueOf(entry.getKey());
             final int level = entry.getValue().getNode(ToolDefinitionConfig.LEVEL).getInt(0);
-            return Optional.of(new ToolDefinition(toolClass, level));
+            return Optional.of(new ToolDefinition(toolType, level));
         }
 
-        final String toolClass = node.getNode(ToolDefinitionConfig.TOOL_CLASS).getString("");
+        final String toolType = node.getNode(ToolDefinitionConfig.TOOL_TYPE).getString("");
         final int level = node.getNode(ToolDefinitionConfig.LEVEL).getInt(0);
 
-        return Optional.of(new ToolDefinition(toolClass, level));
+        return Optional.of(new ToolDefinition(toolType, level));
     };
 
-    private final String toolClass;
+    private final String toolType;
     private final int level;
 
-    ToolDefinition(final String toolClass, final int level) {
+    ToolDefinition(final String toolType, final int level) {
         this.level = level;
-        this.toolClass = toolClass;
+        this.toolType = toolType;
     }
 
     @Override
     public boolean test(final ItemStack stack) {
-        return stack.getItem().getHarvestLevel(stack, this.toolClass, null, null) >= this.level;
+        return stack.getItem().getHarvestLevel(stack, this.toolType, null, null) >= this.level;
     }
 }

--- a/src/main/java/com/almuradev/content/type/item/definition/ToolDefinition.java
+++ b/src/main/java/com/almuradev/content/type/item/definition/ToolDefinition.java
@@ -1,0 +1,51 @@
+/*
+ * This file is part of Almura.
+ *
+ * Copyright (c) AlmuraDev <https://github.com/AlmuraDev/>
+ *
+ * All Rights Reserved.
+ */
+package com.almuradev.content.type.item.definition;
+
+import com.almuradev.toolbox.config.ConfigurationNodeDeserializer;
+import net.minecraft.item.ItemStack;
+import ninja.leaping.configurate.ConfigurationNode;
+
+import java.util.Map;
+import java.util.Optional;
+
+public final class ToolDefinition implements ItemAcceptable {
+
+    public static final ConfigurationNodeDeserializer<ToolDefinition> PARSER = node -> {
+        if (node.isVirtual()) {
+            return Optional.empty();
+        }
+
+        // tool_class:
+        //   level: <value>
+        if (node.getValue() instanceof Map) {
+            final Map.Entry<Object, ? extends ConfigurationNode> entry = node.getChildrenMap().entrySet().iterator().next();
+            final String toolClass = String.valueOf(entry.getKey());
+            final int level = entry.getValue().getNode(ToolDefinitionConfig.LEVEL).getInt(0);
+            return Optional.of(new ToolDefinition(toolClass, level));
+        }
+
+        final String toolClass = node.getNode(ToolDefinitionConfig.TOOL_CLASS).getString("");
+        final int level = node.getNode(ToolDefinitionConfig.LEVEL).getInt(0);
+
+        return Optional.of(new ToolDefinition(toolClass, level));
+    };
+
+    private final String toolClass;
+    private final int level;
+
+    ToolDefinition(final String toolClass, final int level) {
+        this.level = level;
+        this.toolClass = toolClass;
+    }
+
+    @Override
+    public boolean test(final ItemStack stack) {
+        return stack.getItem().getHarvestLevel(stack, this.toolClass, null, null) >= this.level;
+    }
+}

--- a/src/main/java/com/almuradev/content/type/item/definition/ToolDefinitionConfig.java
+++ b/src/main/java/com/almuradev/content/type/item/definition/ToolDefinitionConfig.java
@@ -1,0 +1,13 @@
+/*
+ * This file is part of Almura.
+ *
+ * Copyright (c) AlmuraDev <https://github.com/AlmuraDev/>
+ *
+ * All Rights Reserved.
+ */
+package com.almuradev.content.type.item.definition;
+
+public interface ToolDefinitionConfig {
+    String TOOL_CLASS = "tool_class";
+    String LEVEL = "level";
+}

--- a/src/main/java/com/almuradev/content/type/item/definition/ToolDefinitionConfig.java
+++ b/src/main/java/com/almuradev/content/type/item/definition/ToolDefinitionConfig.java
@@ -8,6 +8,10 @@
 package com.almuradev.content.type.item.definition;
 
 public interface ToolDefinitionConfig {
-    String TOOL_CLASS = "tool_class";
+    /**
+     * Forge refers to this as "tool class". E.g.
+     * {@link net.minecraft.item.Item#getToolClasses(net.minecraft.item.ItemStack)}
+     */
+    String TOOL_TYPE = "tool_type";
     String LEVEL = "level";
 }


### PR DESCRIPTION
Also ensured that every time of check an item stack instead of an item is passed.
Item stacks often carry crucial NBT data utilized by mods, especially IC2 (e.g. Mining drill)

Adds definition of tools. Next time instead of defining what tools work, just define the classes and level needed.
(e.g. instead of iron pickaxe, use tool class "pickaxe" and level 2 instead)

Resolves #515

Signed-off-by: liach <liach@users.noreply.github.com>