### PR TITLE
Prevent over trimming of nicknames in the player list

### DIFF
--- a/src/main/java/com/almuradev/almura/feature/hud/screen/origin/component/panel/UIPlayerListPanel.java
+++ b/src/main/java/com/almuradev/almura/feature/hud/screen/origin/component/panel/UIPlayerListPanel.java
@@ -122,8 +122,8 @@ public class UIPlayerListPanel extends AbstractPanel {
         if (player.getGameType() == GameType.SPECTATOR) {
             name = TextFormatting.ITALIC + name;
         }
-
-        return name.length() >= MAX_DISPLAY_NAME_LENGTH ? name.substring(0, MAX_DISPLAY_NAME_LENGTH_SUBSTRING) + DISPLAY_NAME_TRAILING_DOTS : name;
+        // TODO Find a way to trim nicknames with formating codes
+        return TextFormatting.getTextWithoutFormattingCodes(name).length() >= MAX_DISPLAY_NAME_LENGTH ? name.substring(0, MAX_DISPLAY_NAME_LENGTH_SUBSTRING) + DISPLAY_NAME_TRAILING_DOTS : name;
     }
 
     private static String getDisplayName(final NetworkPlayerInfo player) {


### PR DESCRIPTION
This is a fix to prevent the over trimming of formatted nicknames in the player list
this happens when a player's nick name contains a lot of color codes. the player list will
cut the name very short based on the length of the raw name instead of the displayable length of the name