### PR TITLE
Prevents Non Admins From opening axs screens for other players

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -144,7 +144,7 @@ dependencies {
         transitive = false
     }
     // Attempt to use GD 2.0.3 API change.
-    compile 'com.griefdefender:api:2.0.0-SNAPSHOT'
+    compile 'com.github.bloodmc:GriefDefenderAPI:2.0.0-SNAPSHOT'
     compile "net.kyori:adventure-api:4.9.3"
     compile 'br.net.fabiozumbi12.UltimateChat:UltimateChat-Sponge-56-1.9.1'
     compile 'org.spongepowered:configurate-json:3.5'

--- a/build.gradle
+++ b/build.gradle
@@ -144,7 +144,7 @@ dependencies {
         transitive = false
     }
     // Attempt to use GD 2.0.3 API change.
-    compile 'com.github.bloodmc:GriefDefenderAPI:2.0.0-SNAPSHOT'
+    compile 'com.griefdefender:api:2.0.0-SNAPSHOT'
     compile "net.kyori:adventure-api:4.9.3"
     compile 'br.net.fabiozumbi12.UltimateChat:UltimateChat-Sponge-56-1.9.1'
     compile 'org.spongepowered:configurate-json:3.5'

--- a/src/main/java/com/almuradev/almura/feature/exchange/ExchangeCommandsCreator.java
+++ b/src/main/java/com/almuradev/almura/feature/exchange/ExchangeCommandsCreator.java
@@ -34,7 +34,9 @@ final class ExchangeCommandsCreator {
     private static CommandSpec createManageCommand() {
         return CommandSpec.builder()
             .description(Text.of("Request to manage exchanges"))
-            .arguments(GenericArguments.optional(GenericArguments.requiringPermissionWeak(GenericArguments.player(Text.of("player")), Almura.ID + ".exchange.admin")))
+            .arguments(GenericArguments.optionalWeak(
+                GenericArguments.requiringPermissionWeak(GenericArguments.player(Text.of("player")), Almura.ID + ".exchange.admin"))
+            )
             .permission(Almura.ID + ".exchange.manage")
             .executor((src, args) -> {
                 final Player player = args.<Player>getOne("player").orElse((Player) src);
@@ -52,7 +54,11 @@ final class ExchangeCommandsCreator {
     private static CommandSpec createOpenCommand() {
         return CommandSpec.builder()
             .description(Text.of("Request to open an exchange"))
-            .arguments(GenericArguments.seq(GenericArguments.optional(GenericArguments.requiringPermissionWeak(GenericArguments.player(Text.of("player")), Almura.ID + ".exchange.admin")), GenericArguments.string(Text.of("id"))))
+            .arguments(GenericArguments.seq(
+                GenericArguments.optionalWeak(
+                    GenericArguments.requiringPermissionWeak(GenericArguments.player(Text.of("player")), Almura.ID + ".exchange.admin")),
+                GenericArguments.string(Text.of("id"))
+            ))
             .permission(Almura.ID + ".exchange.open")
             .executor((src, args) -> {
                 final Player player = args.<Player>getOne("player").orElse((Player) src);

--- a/src/main/java/com/almuradev/almura/feature/exchange/ExchangeCommandsCreator.java
+++ b/src/main/java/com/almuradev/almura/feature/exchange/ExchangeCommandsCreator.java
@@ -34,10 +34,10 @@ final class ExchangeCommandsCreator {
     private static CommandSpec createManageCommand() {
         return CommandSpec.builder()
             .description(Text.of("Request to manage exchanges"))
-            .arguments(GenericArguments.playerOrSource(Text.of("player")))
+            .arguments(GenericArguments.optional(GenericArguments.requiringPermissionWeak(GenericArguments.player(Text.of("player")), Almura.ID + ".exchange.admin")))
             .permission(Almura.ID + ".exchange.manage")
             .executor((src, args) -> {
-                final Player player = args.<Player>getOne("player").orElse(null);
+                final Player player = args.<Player>getOne("player").orElse((Player) src);
                 if (player == null) {
                     return CommandResult.empty();
                 }
@@ -52,13 +52,10 @@ final class ExchangeCommandsCreator {
     private static CommandSpec createOpenCommand() {
         return CommandSpec.builder()
             .description(Text.of("Request to open an exchange"))
-            .arguments(GenericArguments.seq(GenericArguments.playerOrSource(Text.of("player")), GenericArguments.string(Text.of("id"))))
+            .arguments(GenericArguments.seq(GenericArguments.optional(GenericArguments.requiringPermissionWeak(GenericArguments.player(Text.of("player")), Almura.ID + ".exchange.admin")), GenericArguments.string(Text.of("id"))))
             .permission(Almura.ID + ".exchange.open")
             .executor((src, args) -> {
-                final Player player = args.<Player>getOne("player").orElse(null);
-                if (player == null) {
-                    return CommandResult.empty();
-                }
+                final Player player = args.<Player>getOne("player").orElse((Player) src);
 
                 final String id = args.<String>getOne("id").orElse(null);
                 if (id == null) {

--- a/src/main/java/com/almuradev/almura/feature/exchange/ExchangeCommandsCreator.java
+++ b/src/main/java/com/almuradev/almura/feature/exchange/ExchangeCommandsCreator.java
@@ -56,7 +56,7 @@ final class ExchangeCommandsCreator {
             .description(Text.of("Request to open an exchange"))
             .arguments(GenericArguments.seq(
                 GenericArguments.optionalWeak(
-                    GenericArguments.requiringPermissionWeak(GenericArguments.player(Text.of("player")), Almura.ID + ".exchange.manage.other")),
+                    GenericArguments.requiringPermissionWeak(GenericArguments.player(Text.of("player")), Almura.ID + ".exchange.open.other")),
                 GenericArguments.string(Text.of("id"))
             ))
             .permission(Almura.ID + ".exchange.open")

--- a/src/main/java/com/almuradev/almura/feature/exchange/ExchangeCommandsCreator.java
+++ b/src/main/java/com/almuradev/almura/feature/exchange/ExchangeCommandsCreator.java
@@ -35,7 +35,7 @@ final class ExchangeCommandsCreator {
         return CommandSpec.builder()
             .description(Text.of("Request to manage exchanges"))
             .arguments(GenericArguments.optionalWeak(
-                GenericArguments.requiringPermissionWeak(GenericArguments.player(Text.of("player")), Almura.ID + ".exchange.admin"))
+                GenericArguments.requiringPermissionWeak(GenericArguments.player(Text.of("player")), Almura.ID + ".exchange.manage.other"))
             )
             .permission(Almura.ID + ".exchange.manage")
             .executor((src, args) -> {
@@ -56,7 +56,7 @@ final class ExchangeCommandsCreator {
             .description(Text.of("Request to open an exchange"))
             .arguments(GenericArguments.seq(
                 GenericArguments.optionalWeak(
-                    GenericArguments.requiringPermissionWeak(GenericArguments.player(Text.of("player")), Almura.ID + ".exchange.admin")),
+                    GenericArguments.requiringPermissionWeak(GenericArguments.player(Text.of("player")), Almura.ID + ".exchange.manage.other")),
                 GenericArguments.string(Text.of("id"))
             ))
             .permission(Almura.ID + ".exchange.open")

--- a/src/main/java/com/almuradev/almura/feature/store/StoreCommandsCreator.java
+++ b/src/main/java/com/almuradev/almura/feature/store/StoreCommandsCreator.java
@@ -34,7 +34,10 @@ final class StoreCommandsCreator {
     private static CommandSpec createManageCommand() {
         return CommandSpec.builder()
             .description(Text.of("Request to manage stores"))
-            .arguments(GenericArguments.optional(GenericArguments.requiringPermissionWeak(GenericArguments.player(Text.of("player")), Almura.ID + ".store.admin")))
+            .arguments(
+                GenericArguments.optionalWeak(
+                    GenericArguments.requiringPermissionWeak(GenericArguments.player(Text.of("player")), Almura.ID + ".store.admin"))
+                )
             .permission(Almura.ID + ".store.manage")
             .executor((src, args) -> {
                 final Player player = args.<Player>getOne("player").orElse((Player) src);
@@ -52,7 +55,11 @@ final class StoreCommandsCreator {
     private static CommandSpec createOpenCommand() {
         return CommandSpec.builder()
             .description(Text.of("Request to open a store"))
-            .arguments(GenericArguments.seq(GenericArguments.optional(GenericArguments.requiringPermissionWeak(GenericArguments.player(Text.of("player")), Almura.ID + ".store.admin")), GenericArguments.string(Text.of("id"))))
+            .arguments(GenericArguments.seq(
+                GenericArguments.optionalWeak(
+                    GenericArguments.requiringPermissionWeak(GenericArguments.player(Text.of("player")), Almura.ID + ".store.admin")), 
+                GenericArguments.string(Text.of("id"))
+            ))
             .permission(Almura.ID + ".store.open")
             .executor((src, args) -> {
                 final Player player = args.<Player>getOne("player").orElse((Player) src);

--- a/src/main/java/com/almuradev/almura/feature/store/StoreCommandsCreator.java
+++ b/src/main/java/com/almuradev/almura/feature/store/StoreCommandsCreator.java
@@ -36,7 +36,7 @@ final class StoreCommandsCreator {
             .description(Text.of("Request to manage stores"))
             .arguments(
                 GenericArguments.optionalWeak(
-                    GenericArguments.requiringPermissionWeak(GenericArguments.player(Text.of("player")), Almura.ID + ".store.admin"))
+                    GenericArguments.requiringPermissionWeak(GenericArguments.player(Text.of("player")), Almura.ID + ".store.manage.other"))
                 )
             .permission(Almura.ID + ".store.manage")
             .executor((src, args) -> {
@@ -57,7 +57,7 @@ final class StoreCommandsCreator {
             .description(Text.of("Request to open a store"))
             .arguments(GenericArguments.seq(
                 GenericArguments.optionalWeak(
-                    GenericArguments.requiringPermissionWeak(GenericArguments.player(Text.of("player")), Almura.ID + ".store.admin")), 
+                    GenericArguments.requiringPermissionWeak(GenericArguments.player(Text.of("player")), Almura.ID + ".store.open.other")), 
                 GenericArguments.string(Text.of("id"))
             ))
             .permission(Almura.ID + ".store.open")

--- a/src/main/java/com/almuradev/almura/feature/store/StoreCommandsCreator.java
+++ b/src/main/java/com/almuradev/almura/feature/store/StoreCommandsCreator.java
@@ -34,10 +34,10 @@ final class StoreCommandsCreator {
     private static CommandSpec createManageCommand() {
         return CommandSpec.builder()
             .description(Text.of("Request to manage stores"))
-            .arguments(GenericArguments.playerOrSource(Text.of("player")))
+            .arguments(GenericArguments.optional(GenericArguments.requiringPermissionWeak(GenericArguments.player(Text.of("player")), Almura.ID + ".store.admin")))
             .permission(Almura.ID + ".store.manage")
             .executor((src, args) -> {
-                final Player player = args.<Player>getOne("player").orElse(null);
+                final Player player = args.<Player>getOne("player").orElse((Player) src);
                 if (player == null) {
                     return CommandResult.empty();
                 }
@@ -52,13 +52,10 @@ final class StoreCommandsCreator {
     private static CommandSpec createOpenCommand() {
         return CommandSpec.builder()
             .description(Text.of("Request to open a store"))
-            .arguments(GenericArguments.seq(GenericArguments.playerOrSource(Text.of("player")), GenericArguments.string(Text.of("id"))))
+            .arguments(GenericArguments.seq(GenericArguments.optional(GenericArguments.requiringPermissionWeak(GenericArguments.player(Text.of("player")), Almura.ID + ".store.admin")), GenericArguments.string(Text.of("id"))))
             .permission(Almura.ID + ".store.open")
             .executor((src, args) -> {
-                final Player player = args.<Player>getOne("player").orElse(null);
-                if (player == null) {
-                    return CommandResult.empty();
-                }
+                final Player player = args.<Player>getOne("player").orElse((Player) src);
 
                 final String id = args.<String>getOne("id").orElse(null);
                 if (id == null) {


### PR DESCRIPTION
This Fix Prevents Non Admins From opening the exchange & store management and normal screens for another play from the commands

WARNING This change hasn't been tested Because I'm making these changes in Github's visual studio online editor thing 